### PR TITLE
Feature/extract run code

### DIFF
--- a/opsml/projects/_run_manager.py
+++ b/opsml/projects/_run_manager.py
@@ -208,6 +208,12 @@ class _RunManager:
         self.thread_executor.submit(get_hw_metrics, interval, self.active_run, queue)
         self.thread_executor.submit(put_hw_metrics, interval, self.active_run, queue)
 
+    def _extract_code(self, dir: Optional[str] = None) -> str:
+        """Extracts and saves current code executing in the project"""
+        print(__file__)
+
+        return "code"
+
     def start_run(
         self,
         run_name: Optional[str] = None,
@@ -244,6 +250,8 @@ class _RunManager:
 
         if log_hardware:
             self._log_hardware_metrics(hardware_interval)
+
+        self._extract_code()
 
         return self.active_run
 

--- a/opsml/projects/_run_manager.py
+++ b/opsml/projects/_run_manager.py
@@ -220,14 +220,14 @@ class _RunManager:
         code_dir = Path(code_dir) if code_dir is not None else None
 
         if code_dir is not None and code_dir.is_dir():
-            for p in code_dir.rglob("*"):
-                if p.is_dir():
+            for _path in code_dir.rglob("*"):
+                if _path.is_dir():
                     continue
 
                 self.active_run.log_artifact_from_file(
-                    name=p.name,
-                    local_path=p,
-                    artifact_path=f"artifacts/code/{p.parent.as_posix()}",
+                    name=_path.name,
+                    local_path=_path,
+                    artifact_path=f"artifacts/code/{_path.parent.as_posix()}",
                 )
             return None
 
@@ -236,16 +236,6 @@ class _RunManager:
             local_path=filename,
             artifact_path="artifacts/code",
         )
-
-        # Get the caller frame to determine the file that called the run
-        # need to back out of _run_manager.py and project.py
-
-        # Get the absolute path
-        # abs_path = os.path.abspath(caller_filename)
-
-        # print(abs_path)
-
-        return "code"
 
     def start_run(
         self,

--- a/opsml/projects/_run_manager.py
+++ b/opsml/projects/_run_manager.py
@@ -8,6 +8,7 @@ import concurrent
 import time
 import uuid
 from datetime import datetime
+from pathlib import Path
 from queue import Empty, Queue
 from typing import Any, Dict, Optional, Union, cast
 
@@ -208,17 +209,51 @@ class _RunManager:
         self.thread_executor.submit(get_hw_metrics, interval, self.active_run, queue)
         self.thread_executor.submit(put_hw_metrics, interval, self.active_run, queue)
 
-    def _extract_code(self, dir: Optional[str] = None) -> str:
+    def _extract_code(
+        self,
+        filename: Path,
+        code_dir: Optional[Union[str, Path]] = None,
+    ) -> None:
         """Extracts and saves current code executing in the project"""
-        print(__file__)
+
+        assert self.active_run is not None, "active_run should not be None"
+        code_dir = Path(code_dir) if code_dir is not None else None
+
+        if code_dir is not None and code_dir.is_dir():
+            for p in code_dir.rglob("*"):
+                if p.is_dir():
+                    continue
+
+                self.active_run.log_artifact_from_file(
+                    name=p.name,
+                    local_path=p,
+                    artifact_path=f"artifacts/code/{p.parent.as_posix()}",
+                )
+            return None
+
+        return self.active_run.log_artifact_from_file(
+            name=filename.name,
+            local_path=filename,
+            artifact_path="artifacts/code",
+        )
+
+        # Get the caller frame to determine the file that called the run
+        # need to back out of _run_manager.py and project.py
+
+        # Get the absolute path
+        # abs_path = os.path.abspath(caller_filename)
+
+        # print(abs_path)
 
         return "code"
 
     def start_run(
         self,
+        filename: Path,
         run_name: Optional[str] = None,
         log_hardware: bool = False,
         hardware_interval: int = _DEFAULT_INTERVAL,
+        code_dir: Optional[Union[str, Path]] = None,
     ) -> ActiveRun:
         """
         Starts a project run
@@ -230,6 +265,12 @@ class _RunManager:
                 Log hardware metrics
             hardware_interval:
                 Interval to log hardware metrics
+            filename:
+                Filename of the script that called the run
+            code_dir:
+                Top-level directory containing code to be logged. If not provided,
+                the directory containing the current file will be used.
+
         """
 
         if self.active_run is not None:
@@ -251,7 +292,7 @@ class _RunManager:
         if log_hardware:
             self._log_hardware_metrics(hardware_interval)
 
-        self._extract_code()
+        self._extract_code(code_dir=code_dir, filename=filename)
 
         return self.active_run
 

--- a/opsml/projects/project.py
+++ b/opsml/projects/project.py
@@ -5,7 +5,9 @@
 # LICENSE file in the root directory of this source tree.
 # pylint: disable=protected-access
 
+import inspect
 from contextlib import contextmanager
+from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional, Union, cast
 
 from opsml.cards import Card
@@ -124,6 +126,7 @@ class OpsmlProject:
         run_name: Optional[str] = None,
         log_hardware: bool = False,
         hardware_interval: int = _DEFAULT_INTERVAL,
+        code_dir: Optional[Union[str, Path]] = None,
     ) -> Iterator[ActiveRun]:
         """
         Starts a new run for the project
@@ -135,13 +138,21 @@ class OpsmlProject:
                 Whether to log hardware metrics
             hardware_interval:
                 Interval to log hardware metrics. Default is 30 seconds.
+            code_dir:
+                Top-level directory containing code to be logged. If not provided,
+                the directory containing the current file will be used.
         """
 
         try:
+            # get filename
+            # need to back out of project.py and contextlib.py
+            filename = Path(inspect.getframeinfo(inspect.currentframe().f_back.f_back).filename)  # type: ignore
             yield self._run_mgr.start_run(
                 run_name=run_name,
                 log_hardware=log_hardware,
                 hardware_interval=hardware_interval,
+                code_dir=code_dir,
+                filename=filename,
             )
 
         except ActiveRunException as error:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -240,7 +240,6 @@ def test_app() -> YieldFixture[TestClient]:
 
     opsml_app = OpsmlApp()
     with TestClient(opsml_app.get_app()) as tc:
-
         try:
             print(os.environ["OPSML_AUTH"])
             # set header if needed
@@ -297,7 +296,6 @@ def aws_storage_client(aws_s3_bucket: Path) -> client.S3StorageClient:
 
 
 def mock_registries(monkeypatch: pytest.MonkeyPatch, test_client: TestClient) -> CardRegistries:
-
     def callable_api() -> TestClient:
         return test_client
 
@@ -1481,11 +1479,14 @@ def huggingface_whisper() -> YieldFixture[Tuple[HuggingFaceModel, TorchData]]:
     # come up with some dummy test data to fake out training.
     data = torch.Tensor(joblib.load("tests/assets/whisper-data.joblib"))
 
-    yield HuggingFaceModel(
-        model=model,
-        sample_data=data,
-        task_type=HuggingFaceTask.TEXT_GENERATION.value,
-    ), TorchData(data=data)
+    yield (
+        HuggingFaceModel(
+            model=model,
+            sample_data=data,
+            task_type=HuggingFaceTask.TEXT_GENERATION.value,
+        ),
+        TorchData(data=data),
+    )
     cleanup()
 
 
@@ -1497,11 +1498,14 @@ def huggingface_openai_gpt() -> YieldFixture[Tuple[HuggingFaceModel, TorchData]]
     model = OpenAIGPTLMHeadModel.from_pretrained("openai-gpt")
     inputs = tokenizer("Hello, my dog is cute", return_tensors="pt")
 
-    yield HuggingFaceModel(
-        model=model,
-        sample_data=inputs,
-        task_type=HuggingFaceTask.TEXT_CLASSIFICATION.value,
-    ), TorchData(data=inputs["input_ids"])
+    yield (
+        HuggingFaceModel(
+            model=model,
+            sample_data=inputs,
+            task_type=HuggingFaceTask.TEXT_CLASSIFICATION.value,
+        ),
+        TorchData(data=inputs["input_ids"]),
+    )
     cleanup()
 
 

--- a/tests/test_projects/test_opsml_project.py
+++ b/tests/test_projects/test_opsml_project.py
@@ -42,7 +42,6 @@ def test_opsml_read_only(
 
     info = ProjectInfo(name="test-exp", repository="test", contact="user@test.com")
     with OpsmlProject(info=info).run() as run:
-
         # Create metrics / params / cards
         run.log_metric(key="m1", value=1.1)
         run.log_metric(key="m2", value=1.2)

--- a/tests/test_projects/test_opsml_project_app.py
+++ b/tests/test_projects/test_opsml_project_app.py
@@ -1,4 +1,5 @@
 import time
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -6,19 +7,23 @@ from starlette.testclient import TestClient
 
 from opsml.projects import OpsmlProject, ProjectInfo
 from opsml.registry.registry import CardRegistries
+from opsml.storage import client
 
 # test_app already performs a few tests with opsml project in client model
 # Adding additional tests here to avoid further cluttering test_app
 
 
-def test_opsml_project_id_creation(test_app: TestClient, api_registries: CardRegistries) -> None:
+def test_opsml_project_id_creation(
+    test_app: TestClient,
+    api_registries: CardRegistries,
+    api_storage_client: client.StorageClientBase,
+) -> None:
     """verify that we can read artifacts / metrics / cards without making a run
     active."""
     info = ProjectInfo(name="project1", repository="test", contact="user@test.com")
     project = OpsmlProject(info=info)
 
     with project.run() as run:
-
         run.log_metric(key="m1", value=1.1)
         run.log_metric(key="m2", value=1.2)
 
@@ -39,6 +44,8 @@ def test_opsml_project_id_creation(test_app: TestClient, api_registries: CardReg
         run.log_graph(name="graph", x=[1, 2, 3], y=[4, 5, 6], graph_style="scatter")
         nbr_metrics = len(run.metrics)
         info.run_id = run.run_id
+
+    assert api_storage_client.exists(Path(run.runcard.uri, "artifacts/code/test_opsml_project_app.py"))
 
     proj = OpsmlProject(info=info)
     runcard = proj.runcard
@@ -78,7 +85,31 @@ def test_opsml_project_id_creation(test_app: TestClient, api_registries: CardReg
     assert project.project_id == 1
 
 
-def test_opsml_project_hardware_metric(test_app: TestClient, api_registries: CardRegistries) -> None:
+def test_opsml_project_log_code_directory(
+    test_app: TestClient,
+    api_registries: CardRegistries,
+    api_storage_client: client.StorageClientBase,
+) -> None:
+    """verify that we can read artifacts / metrics / cards without making a run
+    active."""
+    info = ProjectInfo(name="project1", repository="test", contact="user@test.com")
+    project = OpsmlProject(info=info)
+
+    with project.run(log_hardware=True, hardware_interval=10, code_dir=Path("tests/test_projects")) as run:
+        # Create metrics / params / cards
+        run.log_metric(key="m1", value=1.1)
+        run.log_parameter(key="m1", value="apple")
+
+    assert api_storage_client.exists(
+        Path(run.runcard.uri, "artifacts/code/tests/test_projects/test_opsml_project_app.py")
+    )
+
+
+def test_opsml_project_hardware_metric(
+    test_app: TestClient,
+    api_registries: CardRegistries,
+    api_storage_client: client.StorageClientBase,
+) -> None:
     """verify that we can read artifacts / metrics / cards without making a run
     active."""
     info = ProjectInfo(name="project1", repository="test", contact="user@test.com")

--- a/tests/test_projects/test_opsml_project_app.py
+++ b/tests/test_projects/test_opsml_project_app.py
@@ -108,7 +108,6 @@ def test_opsml_project_log_code_directory(
 def test_opsml_project_hardware_metric(
     test_app: TestClient,
     api_registries: CardRegistries,
-    api_storage_client: client.StorageClientBase,
 ) -> None:
     """verify that we can read artifacts / metrics / cards without making a run
     active."""
@@ -122,5 +121,6 @@ def test_opsml_project_hardware_metric(
         time.sleep(15)
 
     metrics = run.runcard.get_hardware_metrics()
+    assert metrics is not None
     assert len(metrics) == 1
     assert metrics[0]["run_uid"] == run.run_id


### PR DESCRIPTION
## Pull Request

### Short Summary
Adds functionality to log code when executing a run from a project.

A `run` will log the file the run is being executed from by default. If a user wants to log a directory of files, they can provide an optional `code_dir` argument. The `code_dir` argument must be the path to the `code_dir` relative to the path of the executing command.

