### PR TITLE
Bug/challenger comparisons

### DIFF
--- a/opsml/model/challenger.py
+++ b/opsml/model/challenger.py
@@ -127,12 +127,18 @@ class ModelChallenger:
             repository=self._challenger.repository,
         )
 
-        if not bool(champion_records):
+        if not champion_records:
             return None
 
         # indicates challenger has been registered
         if self._challenger.version is not None and len(champion_records) > 1:
-            return champion_records[1]
+            # check for first champions model that has a non None runcard_uid
+            for record in champion_records:
+                if record.get("version") != self._challenger.version and record.get("runcard_uid") is not None:
+                    return record
+                else:
+                    logger.info("No previous version associated with a RunCard. Challenger wins")
+                    return None
 
         # account for cases where challenger is only model in registry
         champion_record = champion_records[0]
@@ -141,7 +147,7 @@ class ModelChallenger:
 
         return champion_record
 
-    def _get_runcard_metric(self, runcard_uid: str, metric_name: str) -> Metric:
+    def _get_runcard_metric(self, runcard_uid: str, metric_name: str) -> Optional[Metric]:
         """
         Loads a RunCard from uid
 
@@ -154,6 +160,10 @@ class ModelChallenger:
         """
         runcard = cast(RunCard, self._registries.run.load_card(uid=runcard_uid))
         metric = runcard.get_metric(name=metric_name)
+
+        if not metric:
+            return None
+
         return metric[0]
 
     def _battle(self, champion: CardInfo, champion_metric: Metric, lower_is_better: bool) -> BattleReport:
@@ -199,10 +209,16 @@ class ModelChallenger:
             )
 
         runcard_id = champion_record.get("runcard_uid")
-        if runcard_id is None:
-            raise ValueError(f"No RunCard is associated with champion: {champion_record}")
-
+        assert runcard_id is not None, "RunCard uid is None"
         champion_metric = self._get_runcard_metric(runcard_uid=runcard_id, metric_name=metric_name)
+
+        if champion_metric is None:
+            logger.info("Metric not found in RunCard. Challenger wins")
+            return BattleReport(
+                champion_name=champion_record.get("name"),
+                champion_version=champion_record.get("version"),
+                challenger_win=True,
+            )
 
         return self._battle(
             champion=CardInfo(
@@ -228,17 +244,44 @@ class ModelChallenger:
             )
 
             if not bool(champion_record):
-                raise ValueError(f"Champion model does not exist. {champion}")
+                logger.error(f"Champion model does not exist. {champion}")
+                battle_reports.append(
+                    BattleReport(
+                        champion_name=champion,
+                        champion_version="not found",
+                        challenger_win=True,
+                    )
+                )
+                continue
 
             champion_card = champion_record[0]
             runcard_uid = champion_card.get("runcard_uid")
             if runcard_uid is None:
-                raise ValueError(f"No RunCard associated with champion: {champion}")
+                logger.error(f"No RunCard associated with champion: {champion}")
+                battle_reports.append(
+                    BattleReport(
+                        champion_name=champion,
+                        champion_version="not runcard",
+                        challenger_win=True,
+                    )
+                )
+                continue
 
             champion_metric = self._get_runcard_metric(
                 runcard_uid=runcard_uid,
                 metric_name=metric_name,
             )
+
+            if champion_metric is None:
+                logger.error(f"No metric found in RunCard associated with champion: {champion}")
+                battle_reports.append(
+                    BattleReport(
+                        champion_name=champion,
+                        champion_version="not found",
+                        challenger_win=True,
+                    )
+                )
+                continue
 
             # update name, repository and version in case of None
             champion.name = champion.name or champion_card.get("name")
@@ -296,9 +339,7 @@ class ModelChallenger:
             # get challenger metric
             if value is None:
                 if self._challenger.metadata.runcard_uid is not None:
-                    self.challenger_metric = self._get_runcard_metric(
-                        self._challenger.metadata.runcard_uid, metric_name=name
-                    )
+                    self.challenger_metric = self._get_runcard_metric(self._challenger.metadata.runcard_uid, metric_name=name)
                 else:
                     raise ValueError("Challenger and champions must be associated with a registered RunCard")
             else:

--- a/opsml/projects/_hw_metrics.py
+++ b/opsml/projects/_hw_metrics.py
@@ -8,8 +8,9 @@ import abc
 import os
 import time
 from typing import Any, Dict, List
-
+import platform
 import psutil
+from pydantic import BaseModel
 
 from opsml.helpers.logging import ArtifactLogger
 from opsml.types import CPUMetrics, HardwareMetrics, MemoryMetrics, NetworkRates
@@ -299,3 +300,13 @@ class HardwareMetricsLogger:
         )
 
         return metrics
+
+
+class ComputeEnvironment(BaseModel):
+    cpu_count: int = psutil.cpu_count(logical=False)
+    memory: int = psutil.virtual_memory().total
+    system: str = platform.system()
+    release: str = platform.release()
+    architecture_bits: str = platform.architecture()[0]
+    python_version: str = platform.python_version()
+    python_compiler: str = platform.python_compiler()

--- a/opsml/projects/_hw_metrics.py
+++ b/opsml/projects/_hw_metrics.py
@@ -6,9 +6,10 @@
 
 import abc
 import os
+import platform
 import time
 from typing import Any, Dict, List
-import platform
+
 import psutil
 from pydantic import BaseModel
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,9 @@ all = [
     "opsml[sklearn_onnx]",
     "opsml[torch_onnx]",
 ]
+gpu = [
+    "nvidia-ml-py>=12.560.30",
+]
 
 [tool.uv]
 dev-dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -2564,6 +2564,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nvidia-ml-py"
+version = "12.560.30"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/10/5f34de4a71db8b2b7ec4269f4a33287f24c23e2857ea3187c977b7bc3604/nvidia-ml-py-12.560.30.tar.gz", hash = "sha256:f0254dc7400647680a072ee02509bfd46102b60bdfeca321576d4d4817e7fe97", size = 39194 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/f3/a69ce0b1a1e12fbf6b2ad9f4c14c9999fdbdf15f2478d210f0fd501ddc98/nvidia_ml_py-12.560.30-py3-none-any.whl", hash = "sha256:fea371c94d63e38a611c17bbb85fe400e9c8ddb9e8684a9cd0e47786a4bc3c73", size = 40526 },
+]
+
+[[package]]
 name = "nvidia-nccl-cu12"
 version = "2.18.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2860,6 +2869,9 @@ gcp-postgres = [
 gcs = [
     { name = "gcsfs" },
 ]
+gpu = [
+    { name = "nvidia-ml-py" },
+]
 mysql = [
     { name = "pymysql" },
 ]
@@ -2956,6 +2968,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.23.3,<1.0.0" },
     { name = "jinja2", marker = "extra == 'server'", specifier = "~=3.1" },
     { name = "joblib", specifier = "~=1.3" },
+    { name = "nvidia-ml-py", marker = "extra == 'gpu'" },
     { name = "onnx", marker = "platform_system == 'Darwin' and extra == 'onnx'", specifier = "~=1.16.0" },
     { name = "onnx", marker = "platform_system == 'Linux' and extra == 'onnx'", specifier = "~=1.16.0" },
     { name = "onnx", marker = "platform_system == 'Windows' and extra == 'onnx'", specifier = "==1.16.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -2968,7 +2968,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.23.3,<1.0.0" },
     { name = "jinja2", marker = "extra == 'server'", specifier = "~=3.1" },
     { name = "joblib", specifier = "~=1.3" },
-    { name = "nvidia-ml-py", marker = "extra == 'gpu'" },
+    { name = "nvidia-ml-py", marker = "extra == 'gpu'", specifier = ">=12.560.30" },
     { name = "onnx", marker = "platform_system == 'Darwin' and extra == 'onnx'", specifier = "~=1.16.0" },
     { name = "onnx", marker = "platform_system == 'Linux' and extra == 'onnx'", specifier = "~=1.16.0" },
     { name = "onnx", marker = "platform_system == 'Windows' and extra == 'onnx'", specifier = "==1.16.1" },


### PR DESCRIPTION
## Pull Request

### Short Summary
The `ModelChallenger` does not currently handle failures well if a model, metric or run is missing. This PR adds better handling logic.

New Challenger Flow:

Scenario: No champion provided
- In the case when no champion is provided, `ModelChallenger` will attempt to load the latest model
  - If no model is found --> challenger wins
  - If models are found, `ModelChallenger` will return the first version that is not the challenger version and has a runcard
  - if a model is found but there is no associated runcard and metrics --> challenger wins
  - If a model and runcard exists, but the metric does not --> challenger wins
  - If model, runcard and metric exists --> run battle report

Scenario: List of champions provided
- If a champion model does not exist --> challenger wins
- If a champion does not have a runcard --> challenger wins
- if metric is missing --> challenger wins
- If model, runcard and metric exist --> run battle report


