### PR TITLE
refactor update logic

### DIFF
--- a/tests/test_registry/test_registry.py
+++ b/tests/test_registry/test_registry.py
@@ -490,12 +490,8 @@ def test_load_data_card(pandas_data: PandasData, db_registries: CardRegistries):
 
     assert loaded_data.interface.data_splits == data.data_splits
 
-    # update
-    loaded_data.version = "1.2.0"
-    registry.update_card(card=loaded_data)
-
     record = registry.query_value_from_card(uid=loaded_data.uid, columns=["version", "timestamp"])
-    assert record["version"] == "1.2.0"
+    assert record["version"] == loaded_data.version
 
 
 def test_datacard_failure(pandas_data: PandasData, db_registries: CardRegistries) -> None:

--- a/tests/test_registry/test_update.py
+++ b/tests/test_registry/test_update.py
@@ -3,14 +3,11 @@ from typing import Tuple
 
 import pytest
 
-from opsml.cards import (
-    ModelCard,
-)
-from opsml.data import (
-    DataInterface,
-)
+from opsml.cards import ModelCard
+from opsml.data import DataInterface
 from opsml.model import ModelInterface
 from opsml.registry import CardRegistries
+from opsml.storage import client
 
 
 def test_update_move_savepaths(
@@ -57,6 +54,85 @@ def test_update_fail(
     sklearn_pipeline: Tuple[ModelInterface, DataInterface],
 ) -> None:
     model_registry = db_registries.model
+    model, _ = sklearn_pipeline
+
+    modelcard = ModelCard(
+        interface=model,
+        name="model1",
+        repository="opsml",
+        contact="opsml",
+        datacard_uid=None,
+    )
+    with pytest.raises(AssertionError) as e:
+        model_registry.update_card(card=modelcard)
+    assert "Card does not exist in registry. Please use register card first" in str(e.value)
+
+    # registry card
+    model_registry.register_card(card=modelcard)
+
+    # register 2nd card
+    modelcard = ModelCard(
+        interface=model,
+        name="model2",
+        repository="opsml",
+        contact="opsml",
+        datacard_uid=None,
+    )
+    # registry card
+    model_registry.register_card(card=modelcard)
+
+    # update second card with first card's name
+    modelcard.name = "model1"
+    with pytest.raises(ValueError) as e:
+        model_registry.update_card(card=modelcard)
+    assert "Card for opsml/model1/1.0.0 already exists with a different uid" in str(e.value)
+
+
+def test_update_move_savepaths_client(
+    api_registries: CardRegistries,
+    sklearn_pipeline: Tuple[ModelInterface, DataInterface],
+    api_storage_client: client.StorageClientBase,
+) -> None:
+    model_registry = api_registries.model
+    model, _ = sklearn_pipeline
+
+    modelcard = ModelCard(
+        interface=model,
+        name="model1",
+        repository="opsml",
+        contact="opsml",
+        datacard_uid=None,
+    )
+    model_registry.register_card(card=modelcard)
+
+    assert api_storage_client.exists(Path(modelcard.uri))
+
+    # update the model card
+    previous_uri = modelcard.uri
+    modelcard = model_registry.load_card(uid=modelcard.uid)
+    modelcard.load_model()
+
+    modelcard.version = "1.0.1"
+    model_registry.update_card(card=modelcard)
+
+    assert previous_uri != modelcard.uri
+    assert api_storage_client.exists(Path(modelcard.uri))
+    assert not api_storage_client.exists(Path(previous_uri))
+
+    # load the model card
+    loaded_modelcard = model_registry.load_card(uid=modelcard.uid)
+
+    assert loaded_modelcard.version == "1.0.1"
+    assert loaded_modelcard.uri == modelcard.uri
+    assert loaded_modelcard.name == modelcard.name
+    assert loaded_modelcard.repository == modelcard.repository
+
+
+def test_update_fail_client(
+    api_registries: CardRegistries,
+    sklearn_pipeline: Tuple[ModelInterface, DataInterface],
+) -> None:
+    model_registry = api_registries.model
     model, _ = sklearn_pipeline
 
     modelcard = ModelCard(

--- a/tests/test_registry/test_update.py
+++ b/tests/test_registry/test_update.py
@@ -1,0 +1,91 @@
+from pathlib import Path
+from typing import Tuple
+
+import pytest
+
+from opsml.cards import (
+    ModelCard,
+)
+from opsml.data import (
+    DataInterface,
+)
+from opsml.model import ModelInterface
+from opsml.registry import CardRegistries
+
+
+def test_update_move_savepaths(
+    db_registries: CardRegistries,
+    sklearn_pipeline: Tuple[ModelInterface, DataInterface],
+) -> None:
+    model_registry = db_registries.model
+    model, _ = sklearn_pipeline
+
+    modelcard = ModelCard(
+        interface=model,
+        name="model1",
+        repository="opsml",
+        contact="opsml",
+        datacard_uid=None,
+    )
+    model_registry.register_card(card=modelcard)
+
+    assert Path(modelcard.uri).exists()
+
+    # update the model card
+    previous_uri = modelcard.uri
+    modelcard = model_registry.load_card(uid=modelcard.uid)
+    modelcard.load_model()
+
+    modelcard.version = "1.0.1"
+    model_registry.update_card(card=modelcard)
+
+    assert previous_uri != modelcard.uri
+    assert Path(modelcard.uri).exists()
+    assert not Path(previous_uri).exists()
+
+    # load the model card
+    loaded_modelcard = model_registry.load_card(uid=modelcard.uid)
+
+    assert loaded_modelcard.version == "1.0.1"
+    assert loaded_modelcard.uri == modelcard.uri
+    assert loaded_modelcard.name == modelcard.name
+    assert loaded_modelcard.repository == modelcard.repository
+
+
+def test_update_fail(
+    db_registries: CardRegistries,
+    sklearn_pipeline: Tuple[ModelInterface, DataInterface],
+) -> None:
+    model_registry = db_registries.model
+    model, _ = sklearn_pipeline
+
+    modelcard = ModelCard(
+        interface=model,
+        name="model1",
+        repository="opsml",
+        contact="opsml",
+        datacard_uid=None,
+    )
+    with pytest.raises(AssertionError) as e:
+        model_registry.update_card(card=modelcard)
+    assert "Card does not exist in registry. Please use register card first" in str(e.value)
+
+    # registry card
+    model_registry.register_card(card=modelcard)
+
+    # register 2nd card
+    modelcard = ModelCard(
+        interface=model,
+        name="model2",
+        repository="opsml",
+        contact="opsml",
+        datacard_uid=None,
+    )
+    # registry card
+    model_registry.register_card(card=modelcard)
+
+    # update second card with first card's name
+    modelcard.name = "model1"
+    with pytest.raises(ValueError) as e:
+        model_registry.update_card(card=modelcard)
+    assert "Card for opsml/model1/1.0.0 already exists with a different uid" in str(e.value)


### PR DESCRIPTION
## Pull Request

### Short Summary
Updates `update_card` logic to (1) delete artifacts in old uri if updated uri is different and (2) add check to see if `repository`, `name` and `version` already exist for a card with a different uid than the update candidate.

### Context
There are a few gotchas todos with update logic. Ideally, we'd like to clean up artifacts when the base uri path changes and we'd also like to ensure users don't accidentally overwrite another card in the registry that shares the same repo, name and version but different uid.

