### PR TITLE
Feature/rollback registration on failure

### DIFF
--- a/crates/opsml_registry/src/registry.rs
+++ b/crates/opsml_registry/src/registry.rs
@@ -336,7 +336,7 @@ impl CardRegistry {
     ) -> Result<(), RegistryError> {
         // Update card attributes
         debug!("Updating card with server response");
-        Self::update_card_with_server_response(&response, card)?;
+        Self::update_card_with_server_response(response, card)?;
 
         // Save card artifacts to temp path
         debug!("Saving card artifacts");

--- a/py-opsml/tests/conftest.py
+++ b/py-opsml/tests/conftest.py
@@ -236,7 +236,7 @@ def custom_interface(example_dataframe):
 
 
 @pytest.fixture
-def incorrect__custom_interface(example_dataframe):
+def incorrect_custom_interface(example_dataframe):
     X_train, y_train, X_test, y_test = example_dataframe
     reg = ensemble.RandomForestClassifier(n_estimators=5)
     reg.fit(X_train.to_numpy(), y_train)

--- a/py-opsml/tests/conftest.py
+++ b/py-opsml/tests/conftest.py
@@ -4,7 +4,7 @@ from opsml.model import Feature
 from opsml.logging import RustyLogger, LoggingConfig, LogLevel
 from opsml.card import RegistryTestHelper
 from opsml.potato_head import Prompt
-from typing import Tuple, Dict, Any
+from typing import Tuple, Dict
 from pydantic import BaseModel
 import sys
 import platform

--- a/py-opsml/tests/registry/test_custom_crud.py
+++ b/py-opsml/tests/registry/test_custom_crud.py
@@ -6,6 +6,7 @@ from opsml import (  # type: ignore
     ModelInterface,
     TaskType,
 )
+from opsml.error import OpsmlError
 import pytest
 from tests.conftest import CustomModel
 from tests.conftest import WINDOWS_EXCLUDE
@@ -56,5 +57,13 @@ def test_crud_artifactcard_failure(
             tags=["foo:bar", "baz:qux"],
         )
 
-        # this should fail
-        reg.register_card(card)
+        with pytest.raises(OpsmlError) as error:
+            reg.register_card(card)
+
+        assert (
+            str(error.value)
+            == "OpsmlError: AttributeError: 'IncorrectCustomModel' object has no attribute 'preprocessor'"
+        )
+
+        # check that no cards are registered
+        assert len(reg.list_cards()) == 0

--- a/py-opsml/tests/registry/test_custom_crud.py
+++ b/py-opsml/tests/registry/test_custom_crud.py
@@ -37,3 +37,24 @@ def test_crud_artifactcard(
         assert loaded_card.interface.model is not None
         assert loaded_card.interface.preprocessor is not None
         assert loaded_card.interface.task_type == TaskType.AnomalyDetection
+
+
+@pytest.mark.skipif(WINDOWS_EXCLUDE, reason="skipping")
+def test_crud_artifactcard_failure(
+    incorrect_custom_interface: ModelInterface,
+):
+    """This test is to check whether the rollback card logic works correctly."""
+    # start server
+    with OpsmlTestServer(True):
+        reg = CardRegistry(registry_type=RegistryType.Model)
+
+        card = ModelCard(
+            interface=incorrect_custom_interface,
+            space="test",
+            name="test",
+            to_onnx=True,
+            tags=["foo:bar", "baz:qux"],
+        )
+
+        # this should fail
+        reg.register_card(card)


### PR DESCRIPTION
## Pull Request

### Short Summary
Adding logic for registry rollbacks.

Currently, card registration follows the path:

(1) - Verify card
(2) - Create a registry record via the server (insert to db)
(3) - Using returned response, update card and encrypt + save artifacts

If the program fails/exits in either steps 2 or 3, the registry record for that card  (and any partially uploaded objects)

This pr adds a rollback function (delete card) that executes if steps 2 or 3 fail, whereupon the registry record will be deleted.

