### PR TITLE
132/update auth sql

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom 0.3.3",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -611,9 +610,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.90.0"
+version = "1.91.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5934beb9403c562bd129a1de1bd51ab67209c05ddf3a4a8c86714120181c860f"
+checksum = "10c7d58f9c99e7d33e5a9b288ec84db24de046add7ba4c1e98baf6b3a5b37fde"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -645,9 +644,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.71.0"
+version = "1.72.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a4fd09d6e863655d99cd2260f271c6d1030dc6bfad68e19e126d2e4c8ceb18"
+checksum = "13118ad30741222f67b1a18e5071385863914da05124652b38e172d6d3d9ce31"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -667,9 +666,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.72.0"
+version = "1.73.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3224ab02ebb3074467a33d57caf6fcb487ca36f3697fdd381b0428dc72380696"
+checksum = "f879a8572b4683a8f84f781695bebf2f25cf11a81a2693c31fc0e0215c2c1726"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -689,9 +688,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.72.0"
+version = "1.73.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6933f189ed1255e78175fbd73fb200c0aae7240d220ed3346f567b0ddca3083"
+checksum = "f1e9c3c24e36183e2f698235ed38dcfbbdff1d09b9232dc866c4be3011e0b47e"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -818,7 +817,7 @@ dependencies = [
  "hyper 0.14.32",
  "hyper 1.6.0",
  "hyper-rustls 0.24.2",
- "hyper-rustls 0.27.6",
+ "hyper-rustls 0.27.7",
  "hyper-util",
  "pin-project-lite",
  "rustls 0.21.12",
@@ -1281,9 +1280,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
 
 [[package]]
 name = "bytecount"
@@ -1343,9 +1342,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.25"
+version = "1.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0fc897dc1e865cc67c0e05a836d9d3f1df3cbe442aa4a9473b18e12624a4951"
+checksum = "956a5e21988b87f372569b66183b78babf23ebc2e744b733e4350a752c4dafac"
 dependencies = [
  "jobserver",
  "libc",
@@ -2127,9 +2126,9 @@ checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
 name = "flate2"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -2514,9 +2513,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -2529,7 +2528,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown 0.15.3",
+ "hashbrown 0.15.4",
 ]
 
 [[package]]
@@ -2756,7 +2755,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "smallvec 1.15.0",
+ "smallvec 1.15.1",
  "tokio",
  "want",
 ]
@@ -2779,9 +2778,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.6"
+version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a01595e11bdcec50946522c32dde3fc6914743000a68b93000965f2f02406d"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.3.1",
  "hyper 1.6.0",
@@ -2813,9 +2812,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c293b6b3d21eca78250dc7dbebd6b9210ec5530e038cbfe0661b5c47ab06e8"
+checksum = "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2896,7 +2895,7 @@ dependencies = [
  "icu_normalizer_data",
  "icu_properties",
  "icu_provider",
- "smallvec 1.15.0",
+ "smallvec 1.15.1",
  "zerovec",
 ]
 
@@ -2952,7 +2951,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
 dependencies = [
  "idna_adapter",
- "smallvec 1.15.0",
+ "smallvec 1.15.1",
  "utf8_iter",
 ]
 
@@ -2983,7 +2982,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.3",
+ "hashbrown 0.15.4",
 ]
 
 [[package]]
@@ -3270,7 +3269,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.15.3",
+ "hashbrown 0.15.4",
 ]
 
 [[package]]
@@ -3588,7 +3587,7 @@ dependencies = [
  "num-iter",
  "num-traits",
  "rand 0.8.5",
- "smallvec 1.15.0",
+ "smallvec 1.15.1",
  "zeroize",
 ]
 
@@ -3911,7 +3910,7 @@ dependencies = [
  "scouter-client",
  "serde",
  "serde_json",
- "serde_qs 0.8.5",
+ "serde_qs 0.15.0",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -4088,7 +4087,6 @@ dependencies = [
  "opsml-types",
  "opsml-utils",
  "password-auth",
- "rand 0.7.3",
  "rand 0.9.1",
  "reqwest",
  "rust-embed",
@@ -4097,7 +4095,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "serde_qs 0.8.5",
+ "serde_qs 0.15.0",
  "sqlx",
  "tempfile",
  "thiserror 2.0.12",
@@ -4188,12 +4186,12 @@ dependencies = [
  "opsml-state",
  "opsml-types",
  "opsml-utils",
- "rand 0.7.3",
+ "rand 0.9.1",
  "rayon",
  "reqwest",
  "serde",
  "serde_json",
- "serde_qs 0.8.5",
+ "serde_qs 0.15.0",
  "tempfile",
  "thiserror 2.0.12",
  "time",
@@ -4359,14 +4357,14 @@ dependencies = [
 
 [[package]]
 name = "papergrid"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30268a8d20c2c0d126b2b6610ab405f16517f6ba9f244d8c59ac2c512a8a1ce7"
+checksum = "6978128c8b51d8f4080631ceb2302ab51e32cc6e8615f735ee2f83fd269ae3f1"
 dependencies = [
- "ahash",
  "ansi-str",
  "ansitok",
  "bytecount",
+ "fnv",
  "unicode-width",
 ]
 
@@ -4395,7 +4393,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "smallvec 1.15.0",
+ "smallvec 1.15.1",
  "windows-targets 0.52.6",
 ]
 
@@ -4630,9 +4628,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "portable-atomic-util"
@@ -5140,9 +5138,9 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bc1ea653e0b2e097db3ebb5b7f678be339620b8041f66b30a308c1d45d36a7f"
+checksum = "bd673deb3d184140109c1e27b043c2354cb79399c3ef304c365fc628092ed773"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -5231,7 +5229,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.6.0",
- "hyper-rustls 0.27.6",
+ "hyper-rustls 0.27.7",
  "hyper-tls",
  "hyper-util",
  "ipnet",
@@ -5939,9 +5937,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
 ]
@@ -6065,9 +6063,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
 ]
@@ -6168,7 +6166,7 @@ dependencies = [
  "futures-intrusive",
  "futures-io",
  "futures-util",
- "hashbrown 0.15.3",
+ "hashbrown 0.15.4",
  "hashlink",
  "indexmap 2.9.0",
  "log",
@@ -6179,7 +6177,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "smallvec 1.15.0",
+ "smallvec 1.15.1",
  "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
@@ -6260,7 +6258,7 @@ dependencies = [
  "serde",
  "sha1",
  "sha2",
- "smallvec 1.15.0",
+ "smallvec 1.15.1",
  "sqlx-core",
  "stringprep",
  "thiserror 2.0.12",
@@ -6298,7 +6296,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "smallvec 1.15.0",
+ "smallvec 1.15.1",
  "sqlx-core",
  "stringprep",
  "thiserror 2.0.12",
@@ -6443,9 +6441,9 @@ dependencies = [
 
 [[package]]
 name = "tabled"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "228d124371171cd39f0f454b58f73ddebeeef3cef3207a82ffea1c29465aea43"
+checksum = "e39a2ee1fbcd360805a771e1b300f78cc88fec7b8d3e2f71cd37bbf23e725c7d"
 dependencies = [
  "ansi-str",
  "ansitok",
@@ -6754,18 +6752,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.9"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.26"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.9.0",
  "serde",
@@ -6777,9 +6775,9 @@ dependencies = [
 
 [[package]]
 name = "toml_write"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -6863,9 +6861,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "1b1ffbcf9c6f6b99d386e7444eb608ba646ae452a36b39737deb9663b610f662"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6874,9 +6872,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
@@ -6913,7 +6911,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sharded-slab",
- "smallvec 1.15.0",
+ "smallvec 1.15.1",
  "thread_local",
  "time",
  "tracing-core",

--- a/crates/opsml_server/src/core/auth/middleware.rs
+++ b/crates/opsml_server/src/core/auth/middleware.rs
@@ -83,7 +83,7 @@ pub async fn auth_api_middleware(
                     )
                 })?;
 
-            let mut user = get_user(&state.sql_client, &expired_claims.sub)
+            let mut user = get_user(&state.sql_client, &expired_claims.sub, None)
                 .await
                 .map_err(|_| {
                     (

--- a/crates/opsml_server/src/core/auth/util.rs
+++ b/crates/opsml_server/src/core/auth/util.rs
@@ -124,7 +124,7 @@ async fn create_user(
     Ok(new_user)
 }
 
-/// Validates a user with OpsML
+/// Validates a user with OpsML when logging in with SSO.
 /// If the user does not exist in the database, it will be created.
 /// # Arguments
 /// * `state` - The application state
@@ -139,7 +139,7 @@ async fn validate_user_with_opsml(
     // check if user exists in db
     match state
         .sql_client
-        .get_user(&user.username)
+        .get_user(&user.username, Some("sso"))
         .await
         .map_err(|e| {
             error!("Failed to get user from database: {}", e);

--- a/crates/opsml_server/src/core/setup.rs
+++ b/crates/opsml_server/src/core/setup.rs
@@ -46,6 +46,7 @@ pub async fn initialize_default_user(
         Some(vec!["admin".to_string()]), // group_permissions
         Some("admin".to_string()), // role
         None,
+        None,
     );
 
     // Insert the user
@@ -69,6 +70,7 @@ pub async fn initialize_default_user(
         ]),
         Some(vec!["user".to_string()]),
         Some("guest".to_string()),
+        None,
         None,
     );
 

--- a/crates/opsml_server/src/core/state.rs
+++ b/crates/opsml_server/src/core/state.rs
@@ -27,7 +27,7 @@ impl AppState {
     ) -> Result<String, ServerError> {
         let user = self
             .sql_client
-            .get_user(&perms.username)
+            .get_user(&perms.username, None)
             .await?
             .ok_or_else(|| {
                 error!("User not found in database");

--- a/crates/opsml_server/src/core/user/utils.rs
+++ b/crates/opsml_server/src/core/user/utils.rs
@@ -27,9 +27,10 @@ use tracing::error;
 pub async fn get_user(
     sql_client: &SqlClientEnum,
     username: &str,
+    auth_type: Option<&str>,
 ) -> Result<User, (StatusCode, Json<OpsmlServerError>)> {
     sql_client
-        .get_user(username)
+        .get_user(username, auth_type)
         .await
         .map_err(|e| {
             error!("Failed to get user from database: {}", e);

--- a/crates/opsml_server/tests/common/mod.rs
+++ b/crates/opsml_server/tests/common/mod.rs
@@ -236,7 +236,7 @@ GrrNOufvPsvmCRO9m4ESRrk=
 -----END PRIVATE KEY-----"#;
 
         let claims = IdTokenClaims {
-            preferred_username: Some("guest".to_string()),
+            preferred_username: Some("sso_guest".to_string()),
             exp: SystemTime::now()
                 .duration_since(UNIX_EPOCH)
                 .unwrap()

--- a/crates/opsml_sql/src/base.rs
+++ b/crates/opsml_sql/src/base.rs
@@ -210,7 +210,11 @@ pub trait SqlClient: Sized {
     /// # Returns
     ///
     /// * `User` - The user
-    async fn get_user(&self, username: &str) -> Result<Option<User>, SqlError>;
+    async fn get_user(
+        &self,
+        username: &str,
+        auth_type: Option<&str>,
+    ) -> Result<Option<User>, SqlError>;
 
     /// update user
     ///

--- a/crates/opsml_sql/src/enums/client.rs
+++ b/crates/opsml_sql/src/enums/client.rs
@@ -293,11 +293,15 @@ impl SqlClient for SqlClientEnum {
         }
     }
 
-    async fn get_user(&self, username: &str) -> Result<Option<User>, SqlError> {
+    async fn get_user(
+        &self,
+        username: &str,
+        auth_type: Option<&str>,
+    ) -> Result<Option<User>, SqlError> {
         match self {
-            SqlClientEnum::Postgres(client) => client.get_user(username).await,
-            SqlClientEnum::Sqlite(client) => client.get_user(username).await,
-            SqlClientEnum::MySql(client) => client.get_user(username).await,
+            SqlClientEnum::Postgres(client) => client.get_user(username, auth_type).await,
+            SqlClientEnum::Sqlite(client) => client.get_user(username, auth_type).await,
+            SqlClientEnum::MySql(client) => client.get_user(username, auth_type).await,
         }
     }
 
@@ -1207,10 +1211,11 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         client.insert_user(&user).await.unwrap();
 
-        let mut user = client.get_user("user").await.unwrap().unwrap();
+        let mut user = client.get_user("user", None).await.unwrap().unwrap();
         assert_eq!(user.username, "user");
         assert_eq!(user.email, "email");
 
@@ -1218,7 +1223,7 @@ mod tests {
         user.active = false;
 
         client.update_user(&user).await.unwrap();
-        let user = client.get_user("user").await.unwrap().unwrap();
+        let user = client.get_user("user", None).await.unwrap().unwrap();
         assert!(!user.active);
 
         // get all users

--- a/crates/opsml_sql/src/enums/client.rs
+++ b/crates/opsml_sql/src/enums/client.rs
@@ -1213,7 +1213,10 @@ mod tests {
             None,
             None,
         );
+        let sso_user = User::new_from_sso("sso_user", "user@email.com");
+
         client.insert_user(&user).await.unwrap();
+        client.insert_user(&sso_user).await.unwrap();
 
         let mut user = client.get_user("user", None).await.unwrap().unwrap();
         assert_eq!(user.username, "user");
@@ -1228,7 +1231,17 @@ mod tests {
 
         // get all users
         let users = client.get_users().await.unwrap();
-        assert_eq!(users.len(), 1);
+        assert_eq!(users.len(), 2);
+
+        let user = client
+            .get_user("sso_user", Some("sso"))
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(user.active);
+
+        // delete
+        client.delete_user("sso_user").await.unwrap();
 
         // delete user
         client.delete_user("user").await.unwrap();

--- a/crates/opsml_sql/src/mysql/client.rs
+++ b/crates/opsml_sql/src/mysql/client.rs
@@ -975,6 +975,7 @@ impl SqlClient for MySqlClient {
             .bind(&favorite_spaces)
             .bind(&user.refresh_token)
             .bind(&user.email)
+            .bind(&user.authentication_type)
             .bind(&user.username)
             .bind(&user.authentication_type)
             .execute(&self.pool)
@@ -1890,7 +1891,10 @@ mod tests {
             None,
             None,
         );
+        let sso_user = User::new_from_sso("sso_user", "user@email.com");
+
         client.insert_user(&user).await.unwrap();
+        client.insert_user(&sso_user).await.unwrap();
 
         let mut user = client.get_user("user", None).await.unwrap().unwrap();
         assert_eq!(user.username, "user");
@@ -1908,7 +1912,17 @@ mod tests {
 
         // get users
         let users = client.get_users().await.unwrap();
-        assert_eq!(users.len(), 1);
+        assert_eq!(users.len(), 2);
+
+        let user = client
+            .get_user("sso_user", Some("sso"))
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(user.active);
+
+        // delete
+        client.delete_user("sso_user").await.unwrap();
 
         // get last admin
         let is_last_admin = client.is_last_admin("user").await.unwrap();

--- a/crates/opsml_sql/src/mysql/helper.rs
+++ b/crates/opsml_sql/src/mysql/helper.rs
@@ -7,6 +7,7 @@ use opsml_utils::utils::is_valid_uuidv7;
 // user
 const INSERT_USER_SQL: &str = include_str!("sql/user/insert_user.sql");
 const GET_USER_SQL: &str = include_str!("sql/user/get_user.sql");
+const GET_USER_AUTH_TYPE_SQL: &str = include_str!("sql/user/get_user_auth_type.sql");
 const GET_USERS_SQL: &str = include_str!("sql/user/get_users.sql");
 const UPDATE_USER_SQL: &str = include_str!("sql/user/update_user.sql");
 const DELETE_USER_SQL: &str = include_str!("sql/user/delete_user.sql");
@@ -68,6 +69,10 @@ impl MySQLQueryHelper {
 
     pub fn get_user_query() -> String {
         GET_USER_SQL.to_string()
+    }
+
+    pub fn get_user_query_by_auth_type() -> String {
+        GET_USER_AUTH_TYPE_SQL.to_string()
     }
 
     pub fn get_users_query() -> String {

--- a/crates/opsml_sql/src/mysql/migrations/20250609175602_add-user-auth-type.sql
+++ b/crates/opsml_sql/src/mysql/migrations/20250609175602_add-user-auth-type.sql
@@ -1,0 +1,5 @@
+-- Add authentication_type column to opsml_user table
+ALTER TABLE opsml_user ADD COLUMN authentication_type VARCHAR(255) NOT NULL DEFAULT 'basic';
+
+-- Update existing users to have authentication_type='basic'
+UPDATE opsml_user SET authentication_type = 'basic' WHERE authentication_type IS NULL;

--- a/crates/opsml_sql/src/mysql/sql/user/get_user.sql
+++ b/crates/opsml_sql/src/mysql/sql/user/get_user.sql
@@ -1,1 +1,1 @@
-SELECT id, created_at, active, username, password_hash, hashed_recovery_codes, permissions, group_permissions, favorite_spaces, role, refresh_token, email, updated_at FROM opsml_user WHERE username = ?;
+SELECT id, created_at, active, username, password_hash, hashed_recovery_codes, permissions, group_permissions, favorite_spaces, role, refresh_token, email, updated_at, authentication_type FROM opsml_user WHERE username = ?;

--- a/crates/opsml_sql/src/mysql/sql/user/get_user_auth_type.sql
+++ b/crates/opsml_sql/src/mysql/sql/user/get_user_auth_type.sql
@@ -1,0 +1,1 @@
+SELECT id, created_at, active, username, password_hash, hashed_recovery_codes, permissions, group_permissions, favorite_spaces, role, refresh_token, email, updated_at, authentication_type FROM opsml_user WHERE username = ? AND authentication_type = ?;

--- a/crates/opsml_sql/src/mysql/sql/user/get_users.sql
+++ b/crates/opsml_sql/src/mysql/sql/user/get_users.sql
@@ -1,1 +1,1 @@
-SELECT id, created_at, active, username, password_hash, hashed_recovery_codes, permissions, group_permissions, favorite_spaces, role, refresh_token, email, updated_at FROM opsml_user;
+SELECT id, created_at, active, username, password_hash, hashed_recovery_codes, permissions, group_permissions, favorite_spaces, role, refresh_token, email, updated_at, authentication_type FROM opsml_user;

--- a/crates/opsml_sql/src/mysql/sql/user/insert_user.sql
+++ b/crates/opsml_sql/src/mysql/sql/user/insert_user.sql
@@ -1,1 +1,1 @@
-INSERT INTO opsml_user (username, password_hash, hashed_recovery_codes, permissions, group_permissions, favorite_spaces, role, active, email) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+INSERT INTO opsml_user (username, password_hash, hashed_recovery_codes, permissions, group_permissions, favorite_spaces, role, active, email, authentication_type) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)

--- a/crates/opsml_sql/src/mysql/sql/user/update_user.sql
+++ b/crates/opsml_sql/src/mysql/sql/user/update_user.sql
@@ -8,5 +8,6 @@ group_permissions = ?,
 favorite_spaces = ?,
 refresh_token = ?,
 email = ?,
+authentication_type = ?,
 updated_at = CURRENT_TIMESTAMP
 WHERE username = ?;

--- a/crates/opsml_sql/src/mysql/sql/user/update_user.sql
+++ b/crates/opsml_sql/src/mysql/sql/user/update_user.sql
@@ -10,4 +10,4 @@ refresh_token = ?,
 email = ?,
 authentication_type = ?,
 updated_at = CURRENT_TIMESTAMP
-WHERE username = ?;
+WHERE username = ? and authentication_type = ?;

--- a/crates/opsml_sql/src/postgres/client.rs
+++ b/crates/opsml_sql/src/postgres/client.rs
@@ -33,6 +33,7 @@ impl FromRow<'_, PgRow> for User {
         let email = row.try_get("email")?;
         let role = row.try_get("role")?;
         let refresh_token = row.try_get("refresh_token")?;
+        let authentication_type: String = row.try_get("authentication_type")?;
 
         let group_permissions: Vec<String> =
             serde_json::from_value(row.try_get("group_permissions")?).unwrap_or_default();
@@ -60,6 +61,7 @@ impl FromRow<'_, PgRow> for User {
             permissions,
             group_permissions,
             favorite_spaces,
+            authentication_type,
         })
     }
 }
@@ -884,19 +886,30 @@ impl SqlClient for PostgresClient {
             .bind(&user.role)
             .bind(user.active)
             .bind(&user.email)
+            .bind(&user.authentication_type)
             .execute(&self.pool)
             .await?;
 
         Ok(())
     }
 
-    async fn get_user(&self, username: &str) -> Result<Option<User>, SqlError> {
-        let query = PostgresQueryHelper::get_user_query();
+    async fn get_user(
+        &self,
+        username: &str,
+        auth_type: Option<&str>,
+    ) -> Result<Option<User>, SqlError> {
+        let query = match auth_type {
+            Some(_) => PostgresQueryHelper::get_user_query_by_auth_type(),
+            None => PostgresQueryHelper::get_user_query(),
+        };
 
-        let user: Option<User> = sqlx::query_as(&query)
-            .bind(username)
-            .fetch_optional(&self.pool)
-            .await?;
+        let mut query_builder = sqlx::query_as(&query).bind(username);
+
+        if let Some(auth_type) = auth_type {
+            query_builder = query_builder.bind(auth_type);
+        }
+
+        let user: Option<User> = query_builder.fetch_optional(&self.pool).await?;
 
         Ok(user)
     }
@@ -919,6 +932,7 @@ impl SqlClient for PostgresClient {
             .bind(&user.refresh_token)
             .bind(&user.email)
             .bind(&user.username)
+            .bind(&user.authentication_type)
             .execute(&self.pool)
             .await?;
 
@@ -1816,11 +1830,12 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         client.insert_user(&user).await.unwrap();
 
         // Read
-        let mut user = client.get_user("user").await.unwrap().unwrap();
+        let mut user = client.get_user("user", None).await.unwrap().unwrap();
 
         assert_eq!(user.username, "user");
         assert_eq!(user.group_permissions, vec!["user"]);
@@ -1832,7 +1847,7 @@ mod tests {
 
         // Update
         client.update_user(&user).await.unwrap();
-        let user = client.get_user("user").await.unwrap().unwrap();
+        let user = client.get_user("user", None).await.unwrap().unwrap();
         assert!(!user.active);
         assert_eq!(user.refresh_token.unwrap(), "token");
 

--- a/crates/opsml_sql/src/postgres/helper.rs
+++ b/crates/opsml_sql/src/postgres/helper.rs
@@ -8,6 +8,7 @@ use opsml_utils::utils::is_valid_uuidv7;
 // user
 const INSERT_USER_SQL: &str = include_str!("sql/user/insert_user.sql");
 const GET_USER_SQL: &str = include_str!("sql/user/get_user.sql");
+const GET_USER_AUTH_TYPE_SQL: &str = include_str!("sql/user/get_user_auth_type.sql");
 const GET_USERS_SQL: &str = include_str!("sql/user/get_users.sql");
 const UPDATE_USER_SQL: &str = include_str!("sql/user/update_user.sql");
 const DELETE_USER_SQL: &str = include_str!("sql/user/delete_user.sql");
@@ -113,6 +114,10 @@ impl PostgresQueryHelper {
 
     pub fn get_user_query() -> String {
         GET_USER_SQL.to_string()
+    }
+
+    pub fn get_user_query_by_auth_type() -> String {
+        GET_USER_AUTH_TYPE_SQL.to_string()
     }
 
     pub fn get_users_query() -> String {

--- a/crates/opsml_sql/src/postgres/migrations/20250609175539_add-user-auth-type.sql
+++ b/crates/opsml_sql/src/postgres/migrations/20250609175539_add-user-auth-type.sql
@@ -1,0 +1,6 @@
+
+-- Add authentication_type column to opsml_user table
+ALTER TABLE opsml_user ADD COLUMN IF NOT EXISTS authentication_type TEXT NOT NULL DEFAULT 'basic';
+
+-- Update existing users to have authentication_type='basic'
+UPDATE opsml_user SET authentication_type = 'basic' WHERE authentication_type IS NULL;

--- a/crates/opsml_sql/src/postgres/sql/user/get_user.sql
+++ b/crates/opsml_sql/src/postgres/sql/user/get_user.sql
@@ -1,1 +1,1 @@
-SELECT id, created_at, active, username, password_hash, hashed_recovery_codes, permissions, group_permissions, favorite_spaces, role, refresh_token, email, updated_at FROM opsml_user WHERE username = $1;
+SELECT id, created_at, active, username, password_hash, hashed_recovery_codes, permissions, group_permissions, favorite_spaces, role, refresh_token, email, updated_at, authentication_type FROM opsml_user WHERE username = $1;

--- a/crates/opsml_sql/src/postgres/sql/user/get_user_auth_type.sql
+++ b/crates/opsml_sql/src/postgres/sql/user/get_user_auth_type.sql
@@ -1,0 +1,1 @@
+SELECT id, created_at, active, username, password_hash, hashed_recovery_codes, permissions, group_permissions, favorite_spaces, role, refresh_token, email, updated_at, authentication_type FROM opsml_user WHERE username = $1 and authentication_type = $2;

--- a/crates/opsml_sql/src/postgres/sql/user/get_users.sql
+++ b/crates/opsml_sql/src/postgres/sql/user/get_users.sql
@@ -1,1 +1,1 @@
-SELECT id, created_at, active, username, password_hash, hashed_recovery_codes, permissions, group_permissions, favorite_spaces, role, refresh_token, email, updated_at FROM opsml_user;
+SELECT id, created_at, active, username, password_hash, hashed_recovery_codes, permissions, group_permissions, favorite_spaces, role, refresh_token, email, updated_at, authentication_type FROM opsml_user;

--- a/crates/opsml_sql/src/postgres/sql/user/insert_user.sql
+++ b/crates/opsml_sql/src/postgres/sql/user/insert_user.sql
@@ -1,1 +1,1 @@
-INSERT INTO opsml_user (username, password_hash, hashed_recovery_codes, permissions, group_permissions, favorite_spaces, role, active, email) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9);
+INSERT INTO opsml_user (username, password_hash, hashed_recovery_codes, permissions, group_permissions, favorite_spaces, role, active, email, authentication_type) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10);

--- a/crates/opsml_sql/src/postgres/sql/user/update_user.sql
+++ b/crates/opsml_sql/src/postgres/sql/user/update_user.sql
@@ -10,4 +10,4 @@ refresh_token = $7,
 email = $8,
 authentication_type = $9,
 updated_at = CURRENT_TIMESTAMP
-WHERE username = $10;
+WHERE username = $10 and authentication_type = $9;

--- a/crates/opsml_sql/src/postgres/sql/user/update_user.sql
+++ b/crates/opsml_sql/src/postgres/sql/user/update_user.sql
@@ -8,5 +8,6 @@ group_permissions = $5,
 favorite_spaces = $6,
 refresh_token = $7,
 email = $8,
+authentication_type = $9,
 updated_at = CURRENT_TIMESTAMP
-WHERE username = $9;
+WHERE username = $10;

--- a/crates/opsml_sql/src/schemas/schema.rs
+++ b/crates/opsml_sql/src/schemas/schema.rs
@@ -1158,7 +1158,7 @@ impl User {
             username: username.to_string(),
             password_hash: "[redacted]".to_string(),
             hashed_recovery_codes: Vec::new(),
-            permissions: vec!["read:all".to_string()],
+            permissions: vec!["read:all".to_string(), "write:all".to_string()],
             group_permissions: vec!["user".to_string()],
             favorite_spaces: Vec::new(),
             role: "user".to_string(),

--- a/crates/opsml_sql/src/schemas/schema.rs
+++ b/crates/opsml_sql/src/schemas/schema.rs
@@ -1111,6 +1111,7 @@ pub struct User {
     pub refresh_token: Option<String>,
     pub email: String,
     pub updated_at: DateTime<Utc>,
+    pub authentication_type: String,
 }
 
 impl User {
@@ -1124,6 +1125,7 @@ impl User {
         group_permissions: Option<Vec<String>>,
         role: Option<String>,
         favorite_spaces: Option<Vec<String>>,
+        authentication_type: Option<String>,
     ) -> Self {
         let created_at = get_utc_datetime();
 
@@ -1141,6 +1143,7 @@ impl User {
             refresh_token: None,
             email,
             updated_at: created_at,
+            authentication_type: authentication_type.unwrap_or("basic".to_string()),
         }
     }
 
@@ -1162,6 +1165,7 @@ impl User {
             refresh_token: None,
             email: email.to_string(),
             updated_at: created_at,
+            authentication_type: "sso".to_string(),
         }
     }
 
@@ -1188,6 +1192,10 @@ impl User {
         );
         map.insert("refresh_token".to_string(), "[redacted]".into());
         map.insert("updated_at".to_string(), self.updated_at.to_string().into());
+        map.insert(
+            "authentication_type".to_string(),
+            self.authentication_type.clone().into(),
+        );
 
         // convert to JSON
         serde_json::to_string(&map).unwrap_or_else(|_| "{}".to_string())
@@ -1208,6 +1216,8 @@ impl std::fmt::Debug for User {
             .field("role", &self.role)
             .field("favorite_spaces", &self.favorite_spaces)
             .field("created_at", &self.created_at)
+            .field("updated_at", &self.updated_at)
+            .field("authentication_type", &self.authentication_type)
             .finish()
     }
 }

--- a/crates/opsml_sql/src/sqlite/client.rs
+++ b/crates/opsml_sql/src/sqlite/client.rs
@@ -1013,6 +1013,7 @@ impl SqlClient for SqliteClient {
             .bind(&favorite_spaces)
             .bind(&user.refresh_token)
             .bind(&user.email)
+            .bind(&user.authentication_type)
             .bind(&user.username)
             .bind(&user.authentication_type)
             .execute(&self.pool)
@@ -1866,18 +1867,21 @@ mod tests {
 
         client.insert_user(&user).await.unwrap();
         client.insert_user(&sso_user).await.unwrap();
-        let mut user = client.get_user("user", None).await.unwrap().unwrap();
-        assert_eq!(user.username, "user");
-        assert_eq!(user.password_hash, "pass");
-        assert_eq!(user.group_permissions, vec!["user"]);
-        assert_eq!(user.email, "email");
+
+        let mut user_to_update = client.get_user("user", None).await.unwrap().unwrap();
+
+        assert_eq!(user_to_update.username, "user");
+        assert_eq!(user_to_update.password_hash, "pass");
+        assert_eq!(user_to_update.group_permissions, vec!["user"]);
+        assert_eq!(user_to_update.email, "email");
 
         // update user
-        user.active = false;
-        user.refresh_token = Some("token".to_string());
+        user_to_update.active = false;
+        user_to_update.refresh_token = Some("token".to_string());
 
-        client.update_user(&user).await.unwrap();
+        client.update_user(&user_to_update).await.unwrap();
         let user = client.get_user("user", None).await.unwrap().unwrap();
+
         assert!(!user.active);
         assert_eq!(user.refresh_token.unwrap(), "token");
 

--- a/crates/opsml_sql/src/sqlite/client.rs
+++ b/crates/opsml_sql/src/sqlite/client.rs
@@ -31,6 +31,7 @@ impl FromRow<'_, SqliteRow> for User {
         let email = row.try_get("email")?;
         let role = row.try_get("role")?;
         let refresh_token = row.try_get("refresh_token")?;
+        let authentication_type: String = row.try_get("authentication_type")?;
 
         let group_permissions: Vec<String> =
             serde_json::from_value(row.try_get("group_permissions")?).unwrap_or_default();
@@ -58,6 +59,7 @@ impl FromRow<'_, SqliteRow> for User {
             permissions,
             group_permissions,
             favorite_spaces,
+            authentication_type,
         })
     }
 }
@@ -925,19 +927,30 @@ impl SqlClient for SqliteClient {
             .bind(&user.role)
             .bind(user.active)
             .bind(&user.email)
+            .bind(&user.authentication_type)
             .execute(&self.pool)
             .await?;
 
         Ok(())
     }
 
-    async fn get_user(&self, username: &str) -> Result<Option<User>, SqlError> {
-        let query = SqliteQueryHelper::get_user_query();
+    async fn get_user(
+        &self,
+        username: &str,
+        auth_type: Option<&str>,
+    ) -> Result<Option<User>, SqlError> {
+        let query = match auth_type {
+            Some(_) => SqliteQueryHelper::get_user_query_by_auth_type(),
+            None => SqliteQueryHelper::get_user_query(),
+        };
 
-        let user: Option<User> = sqlx::query_as(&query)
-            .bind(username)
-            .fetch_optional(&self.pool)
-            .await?;
+        let mut query_builder = sqlx::query_as(&query).bind(username);
+
+        if let Some(auth_type) = auth_type {
+            query_builder = query_builder.bind(auth_type);
+        }
+
+        let user: Option<User> = query_builder.fetch_optional(&self.pool).await?;
 
         Ok(user)
     }
@@ -1001,6 +1014,7 @@ impl SqlClient for SqliteClient {
             .bind(&user.refresh_token)
             .bind(&user.email)
             .bind(&user.username)
+            .bind(&user.authentication_type)
             .execute(&self.pool)
             .await?;
 
@@ -1845,10 +1859,14 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
 
+        let sso_user = User::new_from_sso("sso_user", "user@email.com");
+
         client.insert_user(&user).await.unwrap();
-        let mut user = client.get_user("user").await.unwrap().unwrap();
+        client.insert_user(&sso_user).await.unwrap();
+        let mut user = client.get_user("user", None).await.unwrap().unwrap();
         assert_eq!(user.username, "user");
         assert_eq!(user.password_hash, "pass");
         assert_eq!(user.group_permissions, vec!["user"]);
@@ -1859,13 +1877,23 @@ mod tests {
         user.refresh_token = Some("token".to_string());
 
         client.update_user(&user).await.unwrap();
-        let user = client.get_user("user").await.unwrap().unwrap();
+        let user = client.get_user("user", None).await.unwrap().unwrap();
         assert!(!user.active);
         assert_eq!(user.refresh_token.unwrap(), "token");
 
         // get users
         let users = client.get_users().await.unwrap();
-        assert_eq!(users.len(), 1);
+        assert_eq!(users.len(), 2);
+
+        let user = client
+            .get_user("sso_user", Some("sso"))
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(user.active);
+
+        // delete
+        client.delete_user("sso_user").await.unwrap();
 
         // get last admin
         let is_last_admin = client.is_last_admin("user").await.unwrap();

--- a/crates/opsml_sql/src/sqlite/helper.rs
+++ b/crates/opsml_sql/src/sqlite/helper.rs
@@ -8,6 +8,7 @@ use opsml_utils::utils::is_valid_uuidv7;
 // user
 const INSERT_USER_SQL: &str = include_str!("sql/user/insert_user.sql");
 const GET_USER_SQL: &str = include_str!("sql/user/get_user.sql");
+const GET_USER_AUTH_TYPE_SQL: &str = include_str!("sql/user/get_user_auth_type.sql");
 const GET_USERS_SQL: &str = include_str!("sql/user/get_users.sql");
 const UPDATE_USER_SQL: &str = include_str!("sql/user/update_user.sql");
 const DELETE_USER_SQL: &str = include_str!("sql/user/delete_user.sql");
@@ -68,6 +69,10 @@ impl SqliteQueryHelper {
 
     pub fn get_user_query() -> String {
         GET_USER_SQL.to_string()
+    }
+
+    pub fn get_user_query_by_auth_type() -> String {
+        GET_USER_AUTH_TYPE_SQL.to_string()
     }
 
     pub fn get_users_query() -> String {

--- a/crates/opsml_sql/src/sqlite/migrations/20250609175303_add-user-auth-type.sql
+++ b/crates/opsml_sql/src/sqlite/migrations/20250609175303_add-user-auth-type.sql
@@ -1,0 +1,6 @@
+
+-- Add authentication_type column to opsml_user table
+ALTER TABLE opsml_user ADD COLUMN authentication_type TEXT NOT NULL DEFAULT 'basic';
+
+-- Update existing users to have authentication_type='basic'
+UPDATE opsml_user SET authentication_type = 'basic' WHERE authentication_type IS NULL;

--- a/crates/opsml_sql/src/sqlite/sql/user/get_user.sql
+++ b/crates/opsml_sql/src/sqlite/sql/user/get_user.sql
@@ -1,1 +1,1 @@
-SELECT id, created_at, active, username, password_hash, hashed_recovery_codes, permissions, group_permissions, favorite_spaces, role, refresh_token, email, updated_at FROM opsml_user WHERE username = ?;
+SELECT id, created_at, active, username, password_hash, hashed_recovery_codes, permissions, group_permissions, favorite_spaces, role, refresh_token, email, updated_at, authentication_type FROM opsml_user WHERE username = ?;

--- a/crates/opsml_sql/src/sqlite/sql/user/get_user_auth_type.sql
+++ b/crates/opsml_sql/src/sqlite/sql/user/get_user_auth_type.sql
@@ -1,0 +1,1 @@
+SELECT id, created_at, active, username, password_hash, hashed_recovery_codes, permissions, group_permissions, favorite_spaces, role, refresh_token, email, updated_at, authentication_type FROM opsml_user WHERE username = ? and authentication_type = ?;

--- a/crates/opsml_sql/src/sqlite/sql/user/get_users.sql
+++ b/crates/opsml_sql/src/sqlite/sql/user/get_users.sql
@@ -1,1 +1,1 @@
-SELECT id, created_at, active, username, password_hash, hashed_recovery_codes, permissions, group_permissions, favorite_spaces, role, refresh_token, email, updated_at FROM opsml_user;
+SELECT id, created_at, active, username, password_hash, hashed_recovery_codes, permissions, group_permissions, favorite_spaces, role, refresh_token, email, updated_at, authentication_type FROM opsml_user;

--- a/crates/opsml_sql/src/sqlite/sql/user/insert_user.sql
+++ b/crates/opsml_sql/src/sqlite/sql/user/insert_user.sql
@@ -1,1 +1,1 @@
-INSERT INTO opsml_user (username, password_hash, hashed_recovery_codes, permissions, group_permissions, favorite_spaces, role, active, email) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+INSERT INTO opsml_user (username, password_hash, hashed_recovery_codes, permissions, group_permissions, favorite_spaces, role, active, email, authentication_type) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);

--- a/crates/opsml_sql/src/sqlite/sql/user/update_user.sql
+++ b/crates/opsml_sql/src/sqlite/sql/user/update_user.sql
@@ -8,5 +8,6 @@ group_permissions = ?,
 favorite_spaces = ?,
 refresh_token = ?,
 email = ?,
+authentication_type = ?,
 updated_at = CURRENT_TIMESTAMP
 WHERE username = ?;

--- a/crates/opsml_sql/src/sqlite/sql/user/update_user.sql
+++ b/crates/opsml_sql/src/sqlite/sql/user/update_user.sql
@@ -10,4 +10,4 @@ refresh_token = ?,
 email = ?,
 authentication_type = ?,
 updated_at = CURRENT_TIMESTAMP
-WHERE username = ?;
+WHERE username = ? AND authentication_type = ?;


### PR DESCRIPTION
## Pull Request

### Short Summary
As part of #132 - we need separate queries for getting a user depending on how they are logging in.
When a user is logging in via UI (non-sso) - We need to validate the login info against non-sso users and vice versa. This PR adds an extra query to allow for querying a user by `authentication_type`. Moreover, we've expanded the `get_user` function to accept `auth_type` as an `Option<&str>` which is then matched against to get the right query.

This also required adding a new `authentication_type` column to `opsml_user`

