### PR TITLE
Bug/142/tools get no respect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3870,6 +3870,7 @@ name = "opsml-cards"
 version = "3.0.0-rc.4"
 dependencies = [
  "chrono",
+ "names",
  "opsml-colors",
  "opsml-crypt",
  "opsml-interfaces",
@@ -3993,7 +3994,6 @@ name = "opsml-experiment"
 version = "3.0.0-rc.4"
 dependencies = [
  "chrono",
- "names",
  "opsml-cards",
  "opsml-crypt",
  "opsml-registry",

--- a/crates/opsml_cards/Cargo.toml
+++ b/crates/opsml_cards/Cargo.toml
@@ -9,6 +9,7 @@ doctest = false
 
 [dependencies]
 chrono = { workspace = true }
+names = { workspace = true }
 opsml-colors = { workspace = true }
 opsml-crypt = { workspace = true }
 opsml-interfaces = { workspace = true }

--- a/crates/opsml_cards/src/utils.rs
+++ b/crates/opsml_cards/src/utils.rs
@@ -1,9 +1,9 @@
+use crate::error::CardError;
+use names::Generator;
 use opsml_state::{app_state, StateError};
 use opsml_types::error::TypeError;
 use opsml_types::{CommonKwargs, RegistryType};
 use opsml_utils::{clean_string, validate_name_space_pattern};
-
-use crate::error::CardError;
 
 pub type BaseArgsResult = (String, String, String, String);
 
@@ -51,6 +51,18 @@ impl BaseArgs {
         registry_type: &RegistryType,
     ) -> Result<String, CardError> {
         let config_value = Self::get_config_value(key, registry_type)?;
+
+        // exception for experiment card. If not name provided, default to random name
+        if key == "name" && value.is_none() && config_value.is_none() {
+            if registry_type == &RegistryType::Experiment {
+                let name = value.map(String::from).unwrap_or_else(|| {
+                    let mut generator = Generator::default();
+                    generator.next().unwrap_or_else(|| "experiment".to_string())
+                });
+
+                return Ok(name);
+            }
+        }
 
         Ok(value
             .as_ref()

--- a/crates/opsml_cards/src/utils.rs
+++ b/crates/opsml_cards/src/utils.rs
@@ -53,15 +53,17 @@ impl BaseArgs {
         let config_value = Self::get_config_value(key, registry_type)?;
 
         // exception for experiment card. If not name provided, default to random name
-        if key == "name" && value.is_none() && config_value.is_none() {
-            if registry_type == &RegistryType::Experiment {
-                let name = value.map(String::from).unwrap_or_else(|| {
-                    let mut generator = Generator::default();
-                    generator.next().unwrap_or_else(|| "experiment".to_string())
-                });
+        if key == "name"
+            && value.is_none()
+            && config_value.is_none()
+            && registry_type == &RegistryType::Experiment
+        {
+            let name = value.map(String::from).unwrap_or_else(|| {
+                let mut generator = Generator::default();
+                generator.next().unwrap_or_else(|| "experiment".to_string())
+            });
 
-                return Ok(name);
-            }
+            return Ok(name);
         }
 
         Ok(value

--- a/crates/opsml_experiment/Cargo.toml
+++ b/crates/opsml_experiment/Cargo.toml
@@ -19,7 +19,6 @@ opsml-types = { workspace = true }
 opsml-utils = { workspace = true }
 
 chrono = { workspace = true }
-names = { workspace = true }
 pyo3 = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/opsml_experiment/src/experiment.rs
+++ b/crates/opsml_experiment/src/experiment.rs
@@ -1,7 +1,7 @@
 use crate::error::ExperimentError;
 use crate::HardwareQueue;
 use chrono::{DateTime, Utc};
-use names::Generator;
+
 use opsml_cards::ExperimentCard;
 use opsml_crypt::{decrypt_directory, encrypt_directory};
 use opsml_registry::base::OpsmlRegistry;
@@ -181,13 +181,8 @@ impl Experiment {
         registries: &mut CardRegistries,
         subexperiment: bool,
     ) -> Result<(Bound<'py, PyAny>, String), ExperimentError> {
-        let name = name.map(String::from).unwrap_or_else(|| {
-            let mut generator = Generator::default();
-            generator.next().unwrap_or_else(|| "experiment".to_string())
-        });
-
         debug!("Initializing experiment");
-        let experiment = Self::initialize_experiment(py, space, Some(&name), subexperiment)?;
+        let experiment = Self::initialize_experiment(py, space, name, subexperiment)?;
 
         debug!("Registering experiment");
         let uid = Self::register_experiment(&experiment, registries)?;


### PR DESCRIPTION
## Pull Request

### Short Summary
There was a bug where `start_experiment` always resulted in a random name if one wasn't provided (expected) even when a default tool configuration was provided (unexpected). This was due to the fact that the `name` attribute was being randomly generated if it was none before the `name` var was passed to the base arg validation logic. This moves the random name generation to after the tool config check

#142 

