### PR TITLE
Feature/card deck mapping

### DIFF
--- a/.github/workflows/lints-test.yml
+++ b/.github/workflows/lints-test.yml
@@ -148,6 +148,7 @@ jobs:
         run: |
           make test.unit
           uv run opsml ui start
+          uv run opsml demo
           uv run opsml ui stop
 
       - name: Upload coverage reports to Codecov

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3729,18 +3729,19 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
+checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
 dependencies = [
  "num_enum_derive",
+ "rustversion",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
+checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5794,7 +5795,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "scouter-client"
 version = "0.5.6"
-source = "git+https://github.com/demml/scouter.git?branch=feature%2Fqueue-opsml-compat#178ce731ca4988f9ae1ac3b53c2004cb763a4902"
+source = "git+https://github.com/demml/scouter.git?branch=feature%2Fqueue-opsml-compat#8299b3a832a8894b42e4f0c38d0459a4d0a45539"
 dependencies = [
  "chrono",
  "ndarray",
@@ -5822,7 +5823,7 @@ dependencies = [
 [[package]]
 name = "scouter-dispatch"
 version = "0.5.6"
-source = "git+https://github.com/demml/scouter.git?branch=feature%2Fqueue-opsml-compat#178ce731ca4988f9ae1ac3b53c2004cb763a4902"
+source = "git+https://github.com/demml/scouter.git?branch=feature%2Fqueue-opsml-compat#8299b3a832a8894b42e4f0c38d0459a4d0a45539"
 dependencies = [
  "futures",
  "pyo3",
@@ -5837,7 +5838,7 @@ dependencies = [
 [[package]]
 name = "scouter-drift"
 version = "0.5.6"
-source = "git+https://github.com/demml/scouter.git?branch=feature%2Fqueue-opsml-compat#178ce731ca4988f9ae1ac3b53c2004cb763a4902"
+source = "git+https://github.com/demml/scouter.git?branch=feature%2Fqueue-opsml-compat#8299b3a832a8894b42e4f0c38d0459a4d0a45539"
 dependencies = [
  "chrono",
  "cron",
@@ -5863,7 +5864,7 @@ dependencies = [
 [[package]]
 name = "scouter-events"
 version = "0.5.6"
-source = "git+https://github.com/demml/scouter.git?branch=feature%2Fqueue-opsml-compat#178ce731ca4988f9ae1ac3b53c2004cb763a4902"
+source = "git+https://github.com/demml/scouter.git?branch=feature%2Fqueue-opsml-compat#8299b3a832a8894b42e4f0c38d0459a4d0a45539"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5895,7 +5896,7 @@ dependencies = [
 [[package]]
 name = "scouter-observability"
 version = "0.5.6"
-source = "git+https://github.com/demml/scouter.git?branch=feature%2Fqueue-opsml-compat#178ce731ca4988f9ae1ac3b53c2004cb763a4902"
+source = "git+https://github.com/demml/scouter.git?branch=feature%2Fqueue-opsml-compat#8299b3a832a8894b42e4f0c38d0459a4d0a45539"
 dependencies = [
  "itertools 0.14.0",
  "ndarray",
@@ -5912,7 +5913,7 @@ dependencies = [
 [[package]]
 name = "scouter-profile"
 version = "0.5.6"
-source = "git+https://github.com/demml/scouter.git?branch=feature%2Fqueue-opsml-compat#178ce731ca4988f9ae1ac3b53c2004cb763a4902"
+source = "git+https://github.com/demml/scouter.git?branch=feature%2Fqueue-opsml-compat#8299b3a832a8894b42e4f0c38d0459a4d0a45539"
 dependencies = [
  "chrono",
  "indicatif",
@@ -5934,7 +5935,7 @@ dependencies = [
 [[package]]
 name = "scouter-settings"
 version = "0.5.6"
-source = "git+https://github.com/demml/scouter.git?branch=feature%2Fqueue-opsml-compat#178ce731ca4988f9ae1ac3b53c2004cb763a4902"
+source = "git+https://github.com/demml/scouter.git?branch=feature%2Fqueue-opsml-compat#8299b3a832a8894b42e4f0c38d0459a4d0a45539"
 dependencies = [
  "base64 0.22.1",
  "pyo3",
@@ -5946,7 +5947,7 @@ dependencies = [
 [[package]]
 name = "scouter-types"
 version = "0.5.6"
-source = "git+https://github.com/demml/scouter.git?branch=feature%2Fqueue-opsml-compat#178ce731ca4988f9ae1ac3b53c2004cb763a4902"
+source = "git+https://github.com/demml/scouter.git?branch=feature%2Fqueue-opsml-compat#8299b3a832a8894b42e4f0c38d0459a4d0a45539"
 dependencies = [
  "chrono",
  "colored_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3969,6 +3969,7 @@ dependencies = [
  "reqwest",
  "scouter-client",
  "serde",
+ "serde_json",
  "sysinfo",
  "tabled",
  "tar",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,7 +283,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
  "synstructure",
 ]
 
@@ -295,7 +295,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -492,7 +492,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -523,9 +523,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-config"
@@ -619,9 +619,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.92.0"
+version = "1.93.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f68db68f26c6337fb89c15916d5ac59c1b4224eb0111492a4f7b85c1058f9ca8"
+checksum = "16b9734dc8145b417a3c22eae8769a2879851690982dba718bdc52bd28ad04ce"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -697,9 +697,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.74.0"
+version = "1.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d440e1d368759bd10df0dbdddbfff6473d7cd73e9d9ef2363dc9995ac2d711"
+checksum = "e3258fa707f2f585ee3049d9550954b959002abd59176975150a01d5cf38ae3f"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1044,7 +1044,7 @@ checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1228,7 +1228,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.103",
+ "syn 2.0.104",
  "which",
 ]
 
@@ -1485,7 +1485,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1846,7 +1846,7 @@ checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1867,7 +1867,7 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1920,7 +1920,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2040,12 +2040,12 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2303,7 +2303,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3095,6 +3095,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3367,9 +3376,9 @@ dependencies = [
 
 [[package]]
 name = "metrics-exporter-prometheus"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df88858cd28baaaf2cfc894e37789ed4184be0e1351157aec7bf3c2266c793fd"
+checksum = "2b166dea96003ee2531cf14833efedced545751d800f03535801d833313f8c15"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.9.0",
@@ -3381,9 +3390,9 @@ dependencies = [
 
 [[package]]
 name = "metrics-util"
-version = "0.19.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8496cc523d1f94c1385dd8f0f0c2c480b2b8aeccb5b7e4485ad6365523ae376"
+checksum = "fe8db7a05415d0f919ffb905afa37784f71901c9a773188876984b4f769ab986"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -3469,7 +3478,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3736,7 +3745,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3867,7 +3876,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3896,6 +3905,23 @@ dependencies = [
  "openssl-src",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "opsml-app"
+version = "3.0.0-rc.8"
+dependencies = [
+ "opsml-cards",
+ "opsml-state",
+ "opsml-types",
+ "pyo3",
+ "scouter-client",
+ "serde",
+ "serde_json",
+ "sysinfo",
+ "thiserror 2.0.12",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -3935,6 +3961,7 @@ dependencies = [
  "opsml-version",
  "potato-head",
  "pyo3",
+ "scouter-client",
  "serde",
  "serde_json",
  "sysinfo",
@@ -4566,7 +4593,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4799,12 +4826,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
+checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
 dependencies = [
  "proc-macro2",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4859,7 +4886,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4877,6 +4904,7 @@ version = "3.0.0-rc.8"
 dependencies = [
  "anyhow",
  "mockito",
+ "opsml-app",
  "opsml-cards",
  "opsml-cli",
  "opsml-experiment",
@@ -4950,7 +4978,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4963,7 +4991,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5034,9 +5062,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4e529991f949c5e25755532370b8af5d114acae52326361d68d47af64aa842"
+checksum = "fcebb1209ee276352ef14ff8732e24cc2b02bbac986cd74a4c81bcb2f9881970"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -5269,9 +5297,9 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.32.0"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd673deb3d184140109c1e27b043c2354cb79399c3ef304c365fc628092ed773"
+checksum = "f2f6fd3fd5bb3a9a48819ae5cbad501968f208c1abd139649e7e2cf5d7f4b40b"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -5473,7 +5501,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.103",
+ "syn 2.0.104",
  "walkdir",
 ]
 
@@ -5766,7 +5794,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "scouter-client"
 version = "0.5.6"
-source = "git+https://github.com/demml/scouter.git?tag=v0.5.6#dc5d44b325298593c766ae1ef1aa42337a45059a"
+source = "git+https://github.com/demml/scouter.git?branch=feature%2Fqueue-opsml-compat#178ce731ca4988f9ae1ac3b53c2004cb763a4902"
 dependencies = [
  "chrono",
  "ndarray",
@@ -5785,7 +5813,7 @@ dependencies = [
  "scouter-types",
  "serde",
  "serde_json",
- "serde_qs 0.8.5",
+ "serde_qs 0.15.0",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -5794,7 +5822,7 @@ dependencies = [
 [[package]]
 name = "scouter-dispatch"
 version = "0.5.6"
-source = "git+https://github.com/demml/scouter.git?tag=v0.5.6#dc5d44b325298593c766ae1ef1aa42337a45059a"
+source = "git+https://github.com/demml/scouter.git?branch=feature%2Fqueue-opsml-compat#178ce731ca4988f9ae1ac3b53c2004cb763a4902"
 dependencies = [
  "futures",
  "pyo3",
@@ -5809,12 +5837,12 @@ dependencies = [
 [[package]]
 name = "scouter-drift"
 version = "0.5.6"
-source = "git+https://github.com/demml/scouter.git?tag=v0.5.6#dc5d44b325298593c766ae1ef1aa42337a45059a"
+source = "git+https://github.com/demml/scouter.git?branch=feature%2Fqueue-opsml-compat#178ce731ca4988f9ae1ac3b53c2004cb763a4902"
 dependencies = [
  "chrono",
  "cron",
  "indicatif",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "ndarray",
  "ndarray-stats",
  "noisy_float",
@@ -5835,7 +5863,7 @@ dependencies = [
 [[package]]
 name = "scouter-events"
 version = "0.5.6"
-source = "git+https://github.com/demml/scouter.git?tag=v0.5.6#dc5d44b325298593c766ae1ef1aa42337a45059a"
+source = "git+https://github.com/demml/scouter.git?branch=feature%2Fqueue-opsml-compat#178ce731ca4988f9ae1ac3b53c2004cb763a4902"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5867,9 +5895,9 @@ dependencies = [
 [[package]]
 name = "scouter-observability"
 version = "0.5.6"
-source = "git+https://github.com/demml/scouter.git?tag=v0.5.6#dc5d44b325298593c766ae1ef1aa42337a45059a"
+source = "git+https://github.com/demml/scouter.git?branch=feature%2Fqueue-opsml-compat#178ce731ca4988f9ae1ac3b53c2004cb763a4902"
 dependencies = [
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "ndarray",
  "ndarray-stats",
  "noisy_float",
@@ -5884,11 +5912,11 @@ dependencies = [
 [[package]]
 name = "scouter-profile"
 version = "0.5.6"
-source = "git+https://github.com/demml/scouter.git?tag=v0.5.6#dc5d44b325298593c766ae1ef1aa42337a45059a"
+source = "git+https://github.com/demml/scouter.git?branch=feature%2Fqueue-opsml-compat#178ce731ca4988f9ae1ac3b53c2004cb763a4902"
 dependencies = [
  "chrono",
  "indicatif",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "ndarray",
  "ndarray-stats",
  "noisy_float",
@@ -5906,7 +5934,7 @@ dependencies = [
 [[package]]
 name = "scouter-settings"
 version = "0.5.6"
-source = "git+https://github.com/demml/scouter.git?tag=v0.5.6#dc5d44b325298593c766ae1ef1aa42337a45059a"
+source = "git+https://github.com/demml/scouter.git?branch=feature%2Fqueue-opsml-compat#178ce731ca4988f9ae1ac3b53c2004cb763a4902"
 dependencies = [
  "base64 0.22.1",
  "pyo3",
@@ -5918,7 +5946,7 @@ dependencies = [
 [[package]]
 name = "scouter-types"
 version = "0.5.6"
-source = "git+https://github.com/demml/scouter.git?tag=v0.5.6#dc5d44b325298593c766ae1ef1aa42337a45059a"
+source = "git+https://github.com/demml/scouter.git?branch=feature%2Fqueue-opsml-compat#178ce731ca4988f9ae1ac3b53c2004cb763a4902"
 dependencies = [
  "chrono",
  "colored_json",
@@ -6028,7 +6056,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6351,7 +6379,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6374,7 +6402,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.103",
+ "syn 2.0.104",
  "tokio",
  "url",
 ]
@@ -6542,7 +6570,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6564,9 +6592,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6590,7 +6618,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6630,7 +6658,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6742,7 +6770,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6753,7 +6781,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6859,7 +6887,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -7034,7 +7062,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -7355,7 +7383,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
  "wasm-bindgen-shared",
 ]
 
@@ -7390,7 +7418,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7443,23 +7471,23 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
 dependencies = [
- "webpki-root-certs 1.0.0",
+ "webpki-root-certs 1.0.1",
 ]
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01a83f7e1a9f8712695c03eabe9ed3fbca0feff0152f33f12593e5a6303cb1a4"
+checksum = "86138b15b2b7d561bc4469e77027b8dd005a43dc502e9031d1f5afc8ce1f280e"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
+checksum = "8782dd5a41a24eed3a4f40b606249b3e236ca61adf1f25ea4d45c73de122b502"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -7488,9 +7516,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "0.7.32"
+version = "0.7.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41b5576b9a81633f3e8df296ce0063042a73507636cbe956c61133dd7034ab22"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
 dependencies = [
  "bytemuck",
  "safe_arch",
@@ -7581,7 +7609,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -7592,7 +7620,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -7971,28 +7999,28 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -8012,7 +8040,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
  "synstructure",
 ]
 
@@ -8033,7 +8061,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -8066,7 +8094,7 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3910,7 +3910,7 @@ dependencies = [
 
 [[package]]
 name = "opsml-app"
-version = "3.0.0-rc.8"
+version = "3.0.0-rc.9"
 dependencies = [
  "opsml-cards",
  "opsml-state",
@@ -3927,7 +3927,7 @@ dependencies = [
 
 [[package]]
 name = "opsml-auth"
-version = "3.0.0-rc.8"
+version = "3.0.0-rc.9"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3947,7 +3947,7 @@ dependencies = [
 
 [[package]]
 name = "opsml-cards"
-version = "3.0.0-rc.8"
+version = "3.0.0-rc.9"
 dependencies = [
  "chrono",
  "names",
@@ -3973,7 +3973,7 @@ dependencies = [
 
 [[package]]
 name = "opsml-cli"
-version = "3.0.0-rc.8"
+version = "3.0.0-rc.9"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4009,7 +4009,7 @@ dependencies = [
 
 [[package]]
 name = "opsml-client"
-version = "3.0.0-rc.8"
+version = "3.0.0-rc.9"
 dependencies = [
  "futures",
  "mockito",
@@ -4031,14 +4031,14 @@ dependencies = [
 
 [[package]]
 name = "opsml-colors"
-version = "3.0.0-rc.8"
+version = "3.0.0-rc.9"
 dependencies = [
  "owo-colors",
 ]
 
 [[package]]
 name = "opsml-crypt"
-version = "3.0.0-rc.8"
+version = "3.0.0-rc.9"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",
@@ -4056,7 +4056,7 @@ dependencies = [
 
 [[package]]
 name = "opsml-events"
-version = "3.0.0-rc.8"
+version = "3.0.0-rc.9"
 dependencies = [
  "axum",
  "chrono",
@@ -4073,7 +4073,7 @@ dependencies = [
 
 [[package]]
 name = "opsml-experiment"
-version = "3.0.0-rc.8"
+version = "3.0.0-rc.9"
 dependencies = [
  "chrono",
  "opsml-cards",
@@ -4098,7 +4098,7 @@ dependencies = [
 
 [[package]]
 name = "opsml-interfaces"
-version = "3.0.0-rc.8"
+version = "3.0.0-rc.9"
 dependencies = [
  "opsml-state",
  "opsml-types",
@@ -4119,7 +4119,7 @@ dependencies = [
 
 [[package]]
 name = "opsml-mocks"
-version = "3.0.0-rc.8"
+version = "3.0.0-rc.9"
 dependencies = [
  "mockito",
  "opsml-registry",
@@ -4139,7 +4139,7 @@ dependencies = [
 
 [[package]]
 name = "opsml-registry"
-version = "3.0.0-rc.8"
+version = "3.0.0-rc.9"
 dependencies = [
  "anyhow",
  "opsml-cards",
@@ -4166,7 +4166,7 @@ dependencies = [
 
 [[package]]
 name = "opsml-semver"
-version = "3.0.0-rc.8"
+version = "3.0.0-rc.9"
 dependencies = [
  "pyo3",
  "semver",
@@ -4176,7 +4176,7 @@ dependencies = [
 
 [[package]]
 name = "opsml-server"
-version = "3.0.0-rc.8"
+version = "3.0.0-rc.9"
 dependencies = [
  "anyhow",
  "axum",
@@ -4204,6 +4204,7 @@ dependencies = [
  "opsml-types",
  "opsml-utils",
  "password-auth",
+ "rand 0.7.3",
  "rand 0.9.1",
  "reqwest",
  "rust-embed",
@@ -4227,7 +4228,7 @@ dependencies = [
 
 [[package]]
 name = "opsml-settings"
-version = "3.0.0-rc.8"
+version = "3.0.0-rc.9"
 dependencies = [
  "base64 0.22.1",
  "opsml-types",
@@ -4241,7 +4242,7 @@ dependencies = [
 
 [[package]]
 name = "opsml-sql"
-version = "3.0.0-rc.8"
+version = "3.0.0-rc.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4263,7 +4264,7 @@ dependencies = [
 
 [[package]]
 name = "opsml-state"
-version = "3.0.0-rc.8"
+version = "3.0.0-rc.9"
 dependencies = [
  "futures",
  "opsml-client",
@@ -4278,7 +4279,7 @@ dependencies = [
 
 [[package]]
 name = "opsml-storage"
-version = "3.0.0-rc.8"
+version = "3.0.0-rc.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4320,7 +4321,7 @@ dependencies = [
 
 [[package]]
 name = "opsml-todo"
-version = "3.0.0-rc.8"
+version = "3.0.0-rc.9"
 dependencies = [
  "clap 4.5.40",
  "opsml-colors",
@@ -4331,7 +4332,7 @@ dependencies = [
 
 [[package]]
 name = "opsml-toml"
-version = "3.0.0-rc.8"
+version = "3.0.0-rc.9"
 dependencies = [
  "opsml-types",
  "opsml-version",
@@ -4343,7 +4344,7 @@ dependencies = [
 
 [[package]]
 name = "opsml-types"
-version = "3.0.0-rc.8"
+version = "3.0.0-rc.9"
 dependencies = [
  "chrono",
  "opsml-colors",
@@ -4363,7 +4364,7 @@ dependencies = [
 
 [[package]]
 name = "opsml-utils"
-version = "3.0.0-rc.8"
+version = "3.0.0-rc.9"
 dependencies = [
  "chrono",
  "colored_json",
@@ -4381,7 +4382,7 @@ dependencies = [
 
 [[package]]
 name = "opsml-version"
-version = "3.0.0-rc.8"
+version = "3.0.0-rc.9"
 
 [[package]]
 name = "option-ext"
@@ -4759,7 +4760,7 @@ dependencies = [
 
 [[package]]
 name = "potato-head"
-version = "3.0.0-rc.8"
+version = "3.0.0-rc.9"
 dependencies = [
  "mime_guess",
  "opsml-state",
@@ -4901,7 +4902,7 @@ dependencies = [
 
 [[package]]
 name = "py-opsml"
-version = "3.0.0-rc.8"
+version = "3.0.0-rc.9"
 dependencies = [
  "anyhow",
  "mockito",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5794,8 +5794,8 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scouter-client"
-version = "0.5.6"
-source = "git+https://github.com/demml/scouter.git?branch=feature%2Fqueue-opsml-compat#8299b3a832a8894b42e4f0c38d0459a4d0a45539"
+version = "0.6.0"
+source = "git+https://github.com/demml/scouter.git?tag=v0.6.0#0ae7e4c6b5af6c5c0ee88e407810795cf6ce1764"
 dependencies = [
  "chrono",
  "ndarray",
@@ -5822,8 +5822,8 @@ dependencies = [
 
 [[package]]
 name = "scouter-dispatch"
-version = "0.5.6"
-source = "git+https://github.com/demml/scouter.git?branch=feature%2Fqueue-opsml-compat#8299b3a832a8894b42e4f0c38d0459a4d0a45539"
+version = "0.6.0"
+source = "git+https://github.com/demml/scouter.git?tag=v0.6.0#0ae7e4c6b5af6c5c0ee88e407810795cf6ce1764"
 dependencies = [
  "futures",
  "pyo3",
@@ -5837,8 +5837,8 @@ dependencies = [
 
 [[package]]
 name = "scouter-drift"
-version = "0.5.6"
-source = "git+https://github.com/demml/scouter.git?branch=feature%2Fqueue-opsml-compat#8299b3a832a8894b42e4f0c38d0459a4d0a45539"
+version = "0.6.0"
+source = "git+https://github.com/demml/scouter.git?tag=v0.6.0#0ae7e4c6b5af6c5c0ee88e407810795cf6ce1764"
 dependencies = [
  "chrono",
  "cron",
@@ -5863,8 +5863,8 @@ dependencies = [
 
 [[package]]
 name = "scouter-events"
-version = "0.5.6"
-source = "git+https://github.com/demml/scouter.git?branch=feature%2Fqueue-opsml-compat#8299b3a832a8894b42e4f0c38d0459a4d0a45539"
+version = "0.6.0"
+source = "git+https://github.com/demml/scouter.git?tag=v0.6.0#0ae7e4c6b5af6c5c0ee88e407810795cf6ce1764"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5895,8 +5895,8 @@ dependencies = [
 
 [[package]]
 name = "scouter-observability"
-version = "0.5.6"
-source = "git+https://github.com/demml/scouter.git?branch=feature%2Fqueue-opsml-compat#8299b3a832a8894b42e4f0c38d0459a4d0a45539"
+version = "0.6.0"
+source = "git+https://github.com/demml/scouter.git?tag=v0.6.0#0ae7e4c6b5af6c5c0ee88e407810795cf6ce1764"
 dependencies = [
  "itertools 0.14.0",
  "ndarray",
@@ -5912,8 +5912,8 @@ dependencies = [
 
 [[package]]
 name = "scouter-profile"
-version = "0.5.6"
-source = "git+https://github.com/demml/scouter.git?branch=feature%2Fqueue-opsml-compat#8299b3a832a8894b42e4f0c38d0459a4d0a45539"
+version = "0.6.0"
+source = "git+https://github.com/demml/scouter.git?tag=v0.6.0#0ae7e4c6b5af6c5c0ee88e407810795cf6ce1764"
 dependencies = [
  "chrono",
  "indicatif",
@@ -5934,8 +5934,8 @@ dependencies = [
 
 [[package]]
 name = "scouter-settings"
-version = "0.5.6"
-source = "git+https://github.com/demml/scouter.git?branch=feature%2Fqueue-opsml-compat#8299b3a832a8894b42e4f0c38d0459a4d0a45539"
+version = "0.6.0"
+source = "git+https://github.com/demml/scouter.git?tag=v0.6.0#0ae7e4c6b5af6c5c0ee88e407810795cf6ce1764"
 dependencies = [
  "base64 0.22.1",
  "pyo3",
@@ -5946,8 +5946,8 @@ dependencies = [
 
 [[package]]
 name = "scouter-types"
-version = "0.5.6"
-source = "git+https://github.com/demml/scouter.git?branch=feature%2Fqueue-opsml-compat#8299b3a832a8894b42e4f0c38d0459a4d0a45539"
+version = "0.6.0"
+source = "git+https://github.com/demml/scouter.git?tag=v0.6.0#0ae7e4c6b5af6c5c0ee88e407810795cf6ce1764"
 dependencies = [
  "chrono",
  "colored_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ repository = "https://github.com/demml/opsml"
 
 
 [workspace.dependencies]
+opsml-app = { path = "crates/opsml_app" }
 opsml-auth = { path = "crates/opsml_auth" }
 opsml-cards = { path = "crates/opsml_cards" }
 opsml-cli = { path = "crates/opsml_cli" }
@@ -87,7 +88,7 @@ reqwest = { version = "0.12.*", features = ["json", "stream", "multipart", "rust
 rust-embed = "8.*"
 reqwest-middleware = "0.*"
 rusty-logging = "0.*"
-scouter-client = { git = "https://github.com/demml/scouter.git", tag = "v0.5.6" }
+scouter-client = { git = "https://github.com/demml/scouter.git", branch = "feature/queue-opsml-compat" }
 sha2 = "0.*"
 semver = "1.*"
 serde = { version = "1.*", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "3.0.0-rc.8"
+version = "3.0.0-rc.9"
 authors = ["Steven Forrester <sjforrester32@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ reqwest = { version = "0.12.*", features = ["json", "stream", "multipart", "rust
 rust-embed = "8.*"
 reqwest-middleware = "0.*"
 rusty-logging = "0.*"
-scouter-client = { git = "https://github.com/demml/scouter.git", branch = "feature/queue-opsml-compat" }
+scouter-client = { git = "https://github.com/demml/scouter.git", tag = "v0.6.0" }
 sha2 = "0.*"
 semver = "1.*"
 serde = { version = "1.*", features = ["derive"] }

--- a/crates/opsml_app/Cargo.toml
+++ b/crates/opsml_app/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "opsml-cards"
+name = "opsml-app"
 version = { workspace = true }
 edition = { workspace = true }
 repository = { workspace = true }
@@ -8,18 +8,9 @@ repository = { workspace = true }
 doctest = false
 
 [dependencies]
-chrono = { workspace = true }
-names = { workspace = true }
-opsml-colors = { workspace = true }
-opsml-crypt = { workspace = true }
-opsml-interfaces = { workspace = true }
+opsml-cards = { workspace = true }
 opsml-state = { workspace = true }
-opsml-storage = { workspace = true}
-opsml-toml = { workspace = true }
 opsml-types = { workspace = true }
-opsml-utils = { workspace = true }
-opsml-version = { workspace = true }
-potato-head = { workspace = true }
 pyo3 = { workspace = true }
 scouter-client = { workspace = true }
 serde = { workspace = true }
@@ -31,6 +22,4 @@ tracing = { workspace = true }
 
 [features]
 default = []
-server = ["opsml-storage/server"]
-
 

--- a/crates/opsml_app/src/app.rs
+++ b/crates/opsml_app/src/app.rs
@@ -1,0 +1,78 @@
+use crate::error::AppError;
+use opsml_cards::CardDeck;
+use opsml_state::app_state;
+use opsml_types::{cards::CardDeckMapping, SaveName, Suffix};
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+use scouter_client::ScouterQueue;
+use std::path::{Path, PathBuf};
+/// Load a card map from path
+fn load_card_map(path: &Path) -> Result<CardDeckMapping, AppError> {
+    let card_mapping_path = path.join(SaveName::CardMap).with_extension(Suffix::Json);
+    let mapping = CardDeckMapping::from_path(&card_mapping_path)?;
+    Ok(mapping)
+}
+
+#[pyclass]
+#[derive(Debug)]
+struct AppState {
+    deck: Py<CardDeck>,
+    queue: Option<Py<ScouterQueue>>,
+}
+
+#[pymethods]
+impl AppState {
+    /// This method will load an application state from a path
+    /// This is primarily used for loading an application during api start where a user
+    /// may wish to load an Opsml CardDeck along with the appropriate ScouterQueue for monitoring
+    /// This class and it's functionality may expand in the future
+    ///
+    /// # Arguments
+    /// * `py` - Python interpreter state
+    /// * `path` - The root path to the application directory containing files
+    /// * `load_kwargs` - Load kwargs to pass to the CardDeck loader
+    /// * `transport_config` = The transport config to use with the ScouterQueue. If not provided,
+    /// no queue will be created.
+    #[staticmethod]
+    #[pyo3(signature = (path=None, load_kwargs=None, transport_config=None))]
+    pub fn from_path(
+        py: Python,
+        path: Option<PathBuf>,
+        load_kwargs: Option<&Bound<'_, PyDict>>,
+        transport_config: Option<&Bound<'_, PyAny>>,
+    ) -> Result<Self, AppError> {
+        let path = path.unwrap_or_else(|| PathBuf::from(SaveName::CardDeck));
+        let deck = Py::new(py, CardDeck::from_path_rs(py, &path, load_kwargs)?)?;
+        let card_map_path = path.join(SaveName::CardMap).with_extension(Suffix::Json);
+        let card_map = load_card_map(&card_map_path)?;
+
+        let queue = match transport_config {
+            Some(config) => {
+                // get the opsml state shared runtime
+                let rt = app_state().runtime.clone();
+
+                Some(Py::new(
+                    py,
+                    ScouterQueue::from_path_rs(py, card_map.drift_paths, config, rt)?,
+                )?)
+            }
+            None => None,
+        };
+
+        Ok(AppState { deck, queue })
+    }
+
+    #[getter]
+    pub fn deck<'py>(&self, py: Python<'py>) -> Result<&Bound<'py, CardDeck>, AppError> {
+        Ok(self.deck.bind(py))
+    }
+
+    #[getter]
+    pub fn queue<'py>(&self, py: Python<'py>) -> Result<&Bound<'py, ScouterQueue>, AppError> {
+        if let Some(queue) = &self.queue {
+            Ok(queue.bind(py))
+        } else {
+            Err(AppError::QueueNotFoundError)
+        }
+    }
+}

--- a/crates/opsml_app/src/app.rs
+++ b/crates/opsml_app/src/app.rs
@@ -25,6 +25,25 @@ pub struct AppState {
 
 #[pymethods]
 impl AppState {
+    /// Instantiate a new application state. Typically from_path is used; however, an new/init
+    /// method is provided for consistency with other classes
+    /// # Arguments
+    /// * `deck` - The CardDeck to use for the application state
+    /// * `queue` - An optional ScouterQueue to use for the application state. If not provided,
+    /// no queue will be created.
+    ///
+    /// # Returns
+    /// * `AppState` - The application state containing the CardDeck and optional ScouterQueue  
+    #[new]
+    #[pyo3(signature = (deck, queue=None))]
+    pub fn new(
+        deck: Bound<'_, CardDeck>,
+        queue: Option<Bound<'_, ScouterQueue>>,
+    ) -> Result<Self, AppError> {
+        let deck = deck.unbind();
+        let queue = queue.map(|q| q.unbind());
+        Ok(AppState { deck, queue })
+    }
     /// This method will load an application state from a path
     /// This is primarily used for loading an application during api start where a user
     /// may wish to load an Opsml CardDeck along with the appropriate ScouterQueue for monitoring

--- a/crates/opsml_app/src/error.rs
+++ b/crates/opsml_app/src/error.rs
@@ -1,0 +1,36 @@
+use opsml_cards::error::CardError;
+use opsml_types::error::TypeError;
+use pyo3::PyErr;
+use scouter_client::PyEventError;
+use thiserror::Error;
+use tracing::error;
+#[derive(Error, Debug)]
+pub enum AppError {
+    #[error(transparent)]
+    PyErr(#[from] pyo3::PyErr),
+
+    #[error(transparent)]
+    SerdeError(#[from] serde_json::Error),
+
+    #[error(transparent)]
+    IoError(#[from] std::io::Error),
+
+    #[error(transparent)]
+    QueueError(#[from] PyEventError),
+
+    #[error(transparent)]
+    TypeError(#[from] TypeError),
+
+    #[error("No queue set for application")]
+    QueueNotFoundError,
+
+    #[error(transparent)]
+    CardError(#[from] CardError),
+}
+
+impl From<AppError> for PyErr {
+    fn from(err: AppError) -> PyErr {
+        let msg = err.to_string();
+        pyo3::exceptions::PyRuntimeError::new_err(msg)
+    }
+}

--- a/crates/opsml_app/src/lib.rs
+++ b/crates/opsml_app/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod app;
+pub mod error;

--- a/crates/opsml_app/src/lib.rs
+++ b/crates/opsml_app/src/lib.rs
@@ -1,2 +1,4 @@
 pub mod app;
 pub mod error;
+
+pub use app::AppState;

--- a/crates/opsml_app/src/mod.rs
+++ b/crates/opsml_app/src/mod.rs
@@ -1,0 +1,2 @@
+pub mod app_state;
+pub mod error;

--- a/crates/opsml_cards/src/deck/card_deck.rs
+++ b/crates/opsml_cards/src/deck/card_deck.rs
@@ -533,10 +533,10 @@ impl CardDeck {
             ));
         }
 
-        let mut card_deck = Self::load_card_deck_json(&path)?;
+        let mut card_deck = Self::load_card_deck_json(path)?;
 
         for card in &card_deck.cards {
-            let card_obj = Self::load_card(py, &path, card, load_kwargs)?;
+            let card_obj = Self::load_card(py, path, card, load_kwargs)?;
             card_deck.card_objs.insert(card.alias.clone(), card_obj);
         }
 

--- a/crates/opsml_cards/src/deck/card_deck.rs
+++ b/crates/opsml_cards/src/deck/card_deck.rs
@@ -510,6 +510,21 @@ impl CardDeck {
     ) -> Result<CardDeck, CardError> {
         let path = path.unwrap_or_else(|| PathBuf::from(SaveName::CardDeck));
 
+        let card_deck = Self::from_path_rs(py, &path, load_kwargs)?;
+        Ok(card_deck)
+    }
+
+    pub fn __str__(&self) -> String {
+        PyHelperFuncs::__str__(self)
+    }
+}
+
+impl CardDeck {
+    pub fn from_path_rs(
+        py: Python,
+        path: &Path,
+        load_kwargs: Option<&Bound<'_, PyDict>>,
+    ) -> Result<CardDeck, CardError> {
         // check path exists
         if !path.exists() {
             error!("Path does not exist: {:?}", path);
@@ -528,12 +543,6 @@ impl CardDeck {
         Ok(card_deck)
     }
 
-    pub fn __str__(&self) -> String {
-        PyHelperFuncs::__str__(self)
-    }
-}
-
-impl CardDeck {
     fn load_card(
         py: Python,
         base_path: &Path,

--- a/crates/opsml_cards/src/deck/card_deck.rs
+++ b/crates/opsml_cards/src/deck/card_deck.rs
@@ -226,6 +226,12 @@ impl<'a> IntoIterator for &'a CardList {
     }
 }
 
+impl CardList {
+    pub fn iter(&self) -> std::slice::Iter<'_, Card> {
+        self.cards.iter()
+    }
+}
+
 /// CardDeck is a collection of cards that can be used to create a card deck and load in one call
 #[pyclass]
 #[derive(Debug)]

--- a/crates/opsml_cli/Cargo.toml
+++ b/crates/opsml_cli/Cargo.toml
@@ -25,6 +25,7 @@ dirs = { workspace = true }
 pyo3 = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 sysinfo = { workspace = true }
 tabled = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/opsml_cli/src/actions/download.rs
+++ b/crates/opsml_cli/src/actions/download.rs
@@ -2,6 +2,7 @@ use crate::cli::arg::DownloadCard;
 use crate::cli::arg::IntoQueryArgs;
 use crate::error::CliError;
 use opsml_cards::CardDeck;
+use opsml_cards::ModelCard;
 use opsml_colors::Colorize;
 use opsml_crypt::decrypt_directory;
 use opsml_registry::base::OpsmlRegistry;
@@ -9,10 +10,11 @@ use opsml_storage::storage_client;
 use opsml_types::{
     cards::CardDeckMapping,
     contracts::{ArtifactKey, CardQueryArgs},
-    RegistryType,
+    RegistryType, SaveName, Suffix,
 };
+use opsml_utils::PyHelperFuncs;
 use std::path::Path;
-
+use tracing::debug;
 /// Download all artifacts of a card
 ///
 /// # Arguments
@@ -62,7 +64,7 @@ pub fn download_card(args: &DownloadCard, registry_type: RegistryType) -> Result
     // 3. For each card, get the ArtifactKey, download the artifacts, and decrypt them
     // 4. Save the artifacts to the specified directory
 
-    let key = registry.get_key(query_args)?;
+    let key = registry.get_key(&query_args)?;
 
     let names: Vec<&str> = key
         .storage_key
@@ -90,7 +92,7 @@ pub fn download_deck(args: &DownloadCard) -> Result<(), CliError> {
     // get registry
     let registry = OpsmlRegistry::new(query_args.registry_type.clone())?;
 
-    let key = registry.get_key(query_args)?;
+    let key = registry.get_key(&query_args)?;
     let base_path = args.deck_path();
 
     // delete directory if it exists
@@ -118,35 +120,63 @@ pub fn download_deck(args: &DownloadCard) -> Result<(), CliError> {
 
     let mut mapping = CardDeckMapping::new();
 
-    // Use try_for_each instead of for_each to handle Results
-    card_deck.cards.into_iter().try_for_each(|card| {
-        let query_args = CardQueryArgs {
-            uid: Some(card.uid.clone()),
-            name: Some(card.name.clone()),
-            space: Some(card.space.clone()),
-            version: Some(card.version.clone()),
-            registry_type: card.registry_type.clone(),
-            ..Default::default()
-        };
+    // Download each card in the deck
+    card_deck
+        .cards
+        .iter()
+        .try_for_each(|card| -> Result<(), CliError> {
+            let query_args = CardQueryArgs {
+                uid: Some(card.uid.clone()),
+                name: Some(card.name.clone()),
+                space: Some(card.space.clone()),
+                version: Some(card.version.clone()),
+                registry_type: card.registry_type.clone(),
+                ..Default::default()
+            };
 
-        let key = registry.get_key(&query_args)?;
-        let card_path = base_path.join(&card.alias);
+            let key = registry.get_key(&query_args)?;
+            let card_path = base_path.join(&card.alias);
 
-        if &query_args.registry_type == &RegistryType::Model {
-            // create directory for card
-            std::fs::create_dir_all(&card_path)?;
-        }
+            // Download card artifacts
+            download_card_artifacts(&key, &card_path)?;
+            mapping.add_card_path(&card.alias, &card_path);
 
-        match &query_args.registry_type {
-            RegistryType::Model => {
-                mapping.add_card_path(&card.alias, &card_path);
+            // If model card, load and process drift paths
+            if card.registry_type == RegistryType::Model {
+                let card_json_path = card_path.join(SaveName::Card).with_extension(Suffix::Json);
+                let json_string = std::fs::read_to_string(&card_json_path)?;
+                let modelcard: ModelCard = serde_json::from_str(&json_string)?;
+
+                let drift_paths = modelcard
+                    .metadata
+                    .interface_metadata
+                    .save_metadata
+                    .drift_profile_uri_map;
+
+                match drift_paths {
+                    Some(paths) => {
+                        for (alias, path) in paths {
+                            // create drift alias and path
+                            // {card_path}/{uri} - uri is relative to parent card path in the profile uri map
+                            let drift_path = card_path.join(path.uri);
+                            mapping.add_drift_path(&alias, &drift_path);
+                        }
+                    }
+                    None => {
+                        debug!("ModelCard {} has no drift paths", card.alias);
+                    }
+                }
+                // Optionally: do something with drift_paths
             }
-            _ => {}
-        }
+            Ok(())
+        })?;
 
-        // download card artifacts
-        download_card_artifacts(&key, &card_path)
-    })?;
+    // save mapping to card root dir
+    let mapping_path = base_path
+        .join(SaveName::CardMap)
+        .with_extension(Suffix::Json);
+
+    PyHelperFuncs::save_to_json(mapping, &mapping_path)?;
 
     Ok(())
 }

--- a/crates/opsml_cli/src/error.rs
+++ b/crates/opsml_cli/src/error.rs
@@ -4,6 +4,7 @@ use opsml_registry::error::RegistryError;
 use opsml_storage::storage::error::StorageError;
 use opsml_toml::error::PyProjectTomlError;
 use opsml_types::error::TypeError;
+use opsml_utils::error::PyUtilError;
 use opsml_utils::error::UtilError;
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
@@ -15,6 +16,9 @@ use tracing::error;
 pub enum CliError {
     #[error(transparent)]
     UtilError(#[from] UtilError),
+
+    #[error(transparent)]
+    PyUtilError(#[from] PyUtilError),
 
     #[error(transparent)]
     StorageError(#[from] StorageError),
@@ -69,6 +73,9 @@ pub enum CliError {
 
     #[error("Failed to run opsml demo")]
     FailedToRunDemo,
+
+    #[error(transparent)]
+    SerdeJsonError(#[from] serde_json::Error),
 }
 
 impl From<CliError> for PyErr {

--- a/crates/opsml_client/src/registry.rs
+++ b/crates/opsml_client/src/registry.rs
@@ -207,7 +207,7 @@ impl ClientRegistry {
     }
 
     #[instrument(skip_all)]
-    pub fn get_key(&self, args: CardQueryArgs) -> Result<ArtifactKey, RegistryError> {
+    pub fn get_key(&self, args: &CardQueryArgs) -> Result<ArtifactKey, RegistryError> {
         let query_string = serde_qs::to_string(&args)?;
 
         let response = self

--- a/crates/opsml_mocks/src/std_mock.rs
+++ b/crates/opsml_mocks/src/std_mock.rs
@@ -10,7 +10,6 @@ use std::net::TcpListener as StdTcpListener;
 use std::sync::Arc;
 #[cfg(feature = "server")]
 use std::thread::sleep;
-
 #[cfg(feature = "server")]
 use tokio::{runtime::Runtime, sync::Mutex, task::JoinHandle};
 
@@ -127,6 +126,19 @@ impl ScouterServer {
             .match_query(mockito::Matcher::Any)
             .with_status(200)
             .with_body(serde_json::to_string(&BinnedCustomMetrics::default()).unwrap())
+            .create();
+
+        server
+            .mock("POST", "/scouter/drift")
+            .match_query(mockito::Matcher::Any)
+            .with_status(200)
+            .with_body(
+                serde_json::to_string(&scouter_client::ScouterResponse {
+                    status: "success".to_string(),
+                    message: "Drift records queued for processing".to_string(),
+                })
+                .unwrap(),
+            )
             .create();
 
         Self {

--- a/crates/opsml_registry/src/base.rs
+++ b/crates/opsml_registry/src/base.rs
@@ -167,7 +167,7 @@ impl OpsmlRegistry {
         }
     }
 
-    pub fn get_key(&self, args: CardQueryArgs) -> Result<ArtifactKey, RegistryError> {
+    pub fn get_key(&self, args: &CardQueryArgs) -> Result<ArtifactKey, RegistryError> {
         match self {
             Self::ClientRegistry(client_registry) => Ok(client_registry.get_key(args)?),
             #[cfg(feature = "server")]

--- a/crates/opsml_registry/src/registry.rs
+++ b/crates/opsml_registry/src/registry.rs
@@ -198,7 +198,7 @@ impl CardRegistry {
         }
 
         // Wrap all operations in a single block_on to handle async operations
-        let key = self.registry.get_key(CardQueryArgs {
+        let key = self.registry.get_key(&CardQueryArgs {
             uid,
             name,
             space,
@@ -648,7 +648,7 @@ impl CardRegistry {
         // get key to re-save Card.json
         let uid = registry_card.uid().to_string();
         let key = registry
-            .get_key(CardQueryArgs {
+            .get_key(&CardQueryArgs {
                 uid: Some(uid),
                 registry_type: registry_type.clone(),
                 ..Default::default()

--- a/crates/opsml_registry/src/server/registry.rs
+++ b/crates/opsml_registry/src/server/registry.rs
@@ -484,7 +484,7 @@ pub mod server_logic {
         ) -> Result<(), RegistryError> {
             // get key
             let key = self
-                .get_key(CardQueryArgs {
+                .get_key(&CardQueryArgs {
                     uid: Some(delete_request.uid.to_string()),
                     ..Default::default()
                 })
@@ -513,10 +513,10 @@ pub mod server_logic {
             Ok(())
         }
 
-        pub async fn get_key(&self, args: CardQueryArgs) -> Result<ArtifactKey, RegistryError> {
+        pub async fn get_key(&self, args: &CardQueryArgs) -> Result<ArtifactKey, RegistryError> {
             Ok(self
                 .sql_client
-                .get_card_key_for_loading(&self.table_name, &args)
+                .get_card_key_for_loading(&self.table_name, args)
                 .await?)
         }
 

--- a/crates/opsml_server/src/core/cards/route.rs
+++ b/crates/opsml_server/src/core/cards/route.rs
@@ -219,7 +219,6 @@ pub async fn get_version_page(
     Ok(Json(VersionPageResponse { summaries }))
 }
 
-#[axum::debug_handler]
 pub async fn list_cards(
     State(state): State<Arc<AppState>>,
     Query(params): Query<CardQueryArgs>,

--- a/crates/opsml_types/src/cards/types.rs
+++ b/crates/opsml_types/src/cards/types.rs
@@ -1,7 +1,9 @@
 use crate::types::RegistryType;
 use pyo3::prelude::*;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::fmt;
+use std::path::PathBuf;
 
 #[pyclass(eq, eq_int)]
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
@@ -55,5 +57,29 @@ impl CardTable {
             RegistryType::Prompt => CardTable::Prompt,
             RegistryType::Deck => CardTable::Deck,
         }
+    }
+}
+
+pub struct CardDeckMapping<'a> {
+    pub card_paths: HashMap<&'a str, &'static PathBuf>,
+    pub drift_paths: HashMap<&'a str, &'static PathBuf>,
+}
+
+impl<'a> CardDeckMapping<'a> {
+    pub fn new() -> Self {
+        Self {
+            // this will be the card alias + path
+            card_paths: HashMap::new(),
+
+            // this will be the drift alias + path (if it exists)
+            drift_paths: HashMap::new(),
+        }
+    }
+
+    pub fn add_card_path(&mut self, alias: &'a str, path: &'static PathBuf) {
+        self.card_paths.insert(alias, path);
+    }
+    pub fn add_drift_path(&mut self, alias: &'a str, path: &'static PathBuf) {
+        self.drift_paths.insert(alias, path);
     }
 }

--- a/crates/opsml_types/src/cards/types.rs
+++ b/crates/opsml_types/src/cards/types.rs
@@ -88,7 +88,7 @@ impl CardDeckMapping {
     }
 
     pub fn from_path(path: &Path) -> Result<Self, TypeError> {
-        let json_string = std::fs::read_to_string(&path)?;
+        let json_string = std::fs::read_to_string(path)?;
         let mapping: CardDeckMapping = serde_json::from_str(&json_string)?;
         Ok(mapping)
     }

--- a/crates/opsml_types/src/cards/types.rs
+++ b/crates/opsml_types/src/cards/types.rs
@@ -3,7 +3,7 @@ use pyo3::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[pyclass(eq, eq_int)]
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
@@ -60,12 +60,13 @@ impl CardTable {
     }
 }
 
-pub struct CardDeckMapping<'a> {
-    pub card_paths: HashMap<&'a str, &'static PathBuf>,
-    pub drift_paths: HashMap<&'a str, &'static PathBuf>,
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct CardDeckMapping {
+    pub card_paths: HashMap<String, PathBuf>,
+    pub drift_paths: HashMap<String, PathBuf>,
 }
 
-impl<'a> CardDeckMapping<'a> {
+impl CardDeckMapping {
     pub fn new() -> Self {
         Self {
             // this will be the card alias + path
@@ -76,10 +77,12 @@ impl<'a> CardDeckMapping<'a> {
         }
     }
 
-    pub fn add_card_path(&mut self, alias: &'a str, path: &'static PathBuf) {
-        self.card_paths.insert(alias, path);
+    pub fn add_card_path(&mut self, alias: &str, path: &Path) {
+        self.card_paths
+            .insert(alias.to_string(), path.to_path_buf());
     }
-    pub fn add_drift_path(&mut self, alias: &'a str, path: &'static PathBuf) {
-        self.drift_paths.insert(alias, path);
+    pub fn add_drift_path(&mut self, alias: &str, path: &Path) {
+        self.drift_paths
+            .insert(alias.to_string(), path.to_path_buf());
     }
 }

--- a/crates/opsml_types/src/cards/types.rs
+++ b/crates/opsml_types/src/cards/types.rs
@@ -1,3 +1,4 @@
+use crate::error::TypeError;
 use crate::types::RegistryType;
 use pyo3::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -84,5 +85,11 @@ impl CardDeckMapping {
     pub fn add_drift_path(&mut self, alias: &str, path: &Path) {
         self.drift_paths
             .insert(alias.to_string(), path.to_path_buf());
+    }
+
+    pub fn from_path(path: &Path) -> Result<Self, TypeError> {
+        let json_string = std::fs::read_to_string(&path)?;
+        let mapping: CardDeckMapping = serde_json::from_str(&json_string)?;
+        Ok(mapping)
     }
 }

--- a/crates/opsml_types/src/error.rs
+++ b/crates/opsml_types/src/error.rs
@@ -21,6 +21,12 @@ pub enum TypeError {
 
     #[error("Key not found")]
     MissingKeyError,
+
+    #[error(transparent)]
+    SerdeError(#[from] serde_json::Error),
+
+    #[error(transparent)]
+    IoError(#[from] std::io::Error),
 }
 
 #[derive(Error, Debug)]

--- a/crates/opsml_types/src/types.rs
+++ b/crates/opsml_types/src/types.rs
@@ -342,6 +342,7 @@ pub enum SaveName {
     Prompt,
     ReadMe,
     CardDeck,
+    CardMap,
 }
 
 #[pymethods]
@@ -375,6 +376,7 @@ impl SaveName {
             "prompt" => Some(SaveName::Prompt),
             "README" => Some(SaveName::ReadMe),
             "card_deck" => Some(SaveName::CardDeck),
+            "card_map" => Some(SaveName::CardMap),
             _ => None,
         }
     }
@@ -407,6 +409,7 @@ impl SaveName {
             SaveName::Prompt => "prompt",
             SaveName::ReadMe => "README",
             SaveName::CardDeck => "card_deck",
+            SaveName::CardMap => "card_map",
         }
     }
 
@@ -450,6 +453,7 @@ impl AsRef<Path> for SaveName {
             SaveName::Prompt => Path::new("prompt"),
             SaveName::ReadMe => Path::new("README"),
             SaveName::CardDeck => Path::new("card_deck"),
+            SaveName::CardMap => Path::new("card_map"),
         }
     }
 }

--- a/py-opsml/Cargo.toml
+++ b/py-opsml/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 anyhow = { workspace = true }
+opsml-app = { workspace = true }
 opsml-cards = { workspace = true }
 mockito = { workspace = true, optional = true }
 opsml-cli = { workspace = true }

--- a/py-opsml/pyproject.toml
+++ b/py-opsml/pyproject.toml
@@ -43,7 +43,7 @@ polars = [
 
 [dependency-groups]
 dev = [
-    "fastapi >= 0.115.0, < 1.0.0",
+    "fastapi>=0.115.0,<1.0.0",
     "maturin >= 1.4.0, < 2.0.0",
     "pytest >= 7.0.0, < 8.0.0",
     "pytest-cov >= 5.0.0, < 6.0.0",

--- a/py-opsml/pyproject.toml
+++ b/py-opsml/pyproject.toml
@@ -6,7 +6,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
-version = "3.0.0-rc.8"
+version = "3.0.0-rc.9"
 description = ""
 authors = [{name = "Thorrester", email = "<support@demmlai.com>"}]
 readme = "README.md"

--- a/py-opsml/python/opsml/__init__.py
+++ b/py-opsml/python/opsml/__init__.py
@@ -2,6 +2,7 @@
 # pylint: disable=no-name-in-module
 
 from .opsml import (  # noqa: F401
+    app,
     card,
     cli,
     data,
@@ -12,7 +13,6 @@ from .opsml import (  # noqa: F401
     potato_head,
     scouter,
     types,
-    app,
 )
 
 CardRegistry = card.CardRegistry

--- a/py-opsml/python/opsml/__init__.py
+++ b/py-opsml/python/opsml/__init__.py
@@ -12,6 +12,7 @@ from .opsml import (  # noqa: F401
     potato_head,
     scouter,
     types,
+    app,
 )
 
 CardRegistry = card.CardRegistry

--- a/py-opsml/python/opsml/app/__init__.py
+++ b/py-opsml/python/opsml/app/__init__.py
@@ -1,0 +1,7 @@
+# type: ignore
+
+from .. import app
+
+AppState = app.AppState
+
+__all__ = ["AppState"]

--- a/py-opsml/python/opsml/app/__init__.pyi
+++ b/py-opsml/python/opsml/app/__init__.pyi
@@ -1,7 +1,12 @@
+# pylint: disable=dangerous-default-value
+# type: ignore
+
+from pathlib import Path
+from typing import Any, Dict, Optional, Union
+
 from ..card import CardDeck
-from ..scouter.queue import ScouterQueue, KafkaConfig, RedisConfig, RabbitMQConfig
 from ..scouter.client import HTTPConfig
-from typing import Optional, Dict, Any, Union
+from ..scouter.queue import KafkaConfig, RabbitMQConfig, RedisConfig, ScouterQueue
 
 class AppState:
     """OpsML application state object. This is typically used in API
@@ -29,7 +34,7 @@ class AppState:
 
     @staticmethod
     def from_path(
-        path: str,
+        path: Path,
         load_kwargs: Optional[Dict[str, Dict[str, Any]]] = None,
         transport_config: Optional[
             Union[
@@ -78,3 +83,11 @@ class AppState:
         Returns:
             AppState: The loaded AppState.
         """
+
+    @property
+    def deck(self) -> CardDeck:
+        """Get the card deck."""
+
+    @property
+    def queue(self) -> ScouterQueue:
+        """Get the Scouter queue."""

--- a/py-opsml/python/opsml/app/__init__.pyi
+++ b/py-opsml/python/opsml/app/__init__.pyi
@@ -1,0 +1,80 @@
+from ..card import CardDeck
+from ..scouter.queue import ScouterQueue, KafkaConfig, RedisConfig, RabbitMQConfig
+from ..scouter.client import HTTPConfig
+from typing import Optional, Dict, Any, Union
+
+class AppState:
+    """OpsML application state object. This is typically used in API
+    workflows where you wish create a shared state to share among all requests.
+    The OpsML app state provides a convenient way to load and store artifacts.
+    Most notably, it provides an integration with Scouter so that you can load a `CardDeck`
+    along with a `ScouterQueue` for drift detection. Future iterations of this class may
+    include other convenience methods that simplify common API tasks.
+    """
+
+    def __init__(
+        self,
+        deck: CardDeck,
+        queue: Optional[ScouterQueue] = None,
+    ):
+        """
+        Initialize the AppState with a CardDeck and a ScouterQueue.
+
+        Args:
+            deck (CardDeck):
+                The card deck containing Cards.
+            queue (ScouterQueue):
+                The Scouter queue for drift detection.
+        """
+
+    @staticmethod
+    def from_path(
+        path: str,
+        load_kwargs: Optional[Dict[str, Dict[str, Any]]] = None,
+        transport_config: Optional[
+            Union[
+                KafkaConfig,
+                RabbitMQConfig,
+                RedisConfig,
+                HTTPConfig,
+            ]
+        ] = None,
+    ) -> "AppState":
+        """
+        Load the AppState from a file path.
+
+        Args:
+            path (str):
+                The file path to load the AppState from. This is typically the path
+                pointing to the directory containing the `CardDeck`.
+            load_kwargs (Dict[str, Dict[str, Any]]):
+                Optional kwargs for loading cards. Expected format:
+                {
+                    "card_alias": {
+                        "interface": interface_object,
+                        "load_kwargs": DataLoadKwargs | ModelLoadKwargs
+                    }
+                }
+            transport_config (Union[KafkaConfig, RabbitMQConfig, RedisConfig, HTTPConfig]) | None:
+                Optional transport configuration for the queue publisher
+                Can be KafkaConfig, RabbitMQConfig RedisConfig, or HTTPConfig. If not provided,
+                the queue will not be initialized.
+
+        Example:
+            ```python
+            from opsml.app import AppState
+            from opsml.scouter import KafkaConfig
+
+            app_state = AppState.from_path(
+                "/path/to/card_deck",
+                transport_config=KafkaConfig(),
+                )
+
+            # Access the card deck and queue
+            deck = app_state.deck
+            queue = app_state.queue
+            ```
+
+        Returns:
+            AppState: The loaded AppState.
+        """

--- a/py-opsml/src/app.rs
+++ b/py-opsml/src/app.rs
@@ -1,0 +1,9 @@
+use opsml_app::AppState;
+use pyo3::prelude::*;
+
+#[pymodule]
+pub fn app(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    // opsml_logging
+    m.add_class::<AppState>()?;
+    Ok(())
+}

--- a/py-opsml/src/lib.rs
+++ b/py-opsml/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod app;
 pub mod card;
 pub mod cli;
 pub mod data;
@@ -22,6 +23,7 @@ fn opsml(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pymodule!(model::model))?;
     m.add_wrapped(wrap_pymodule!(card::card))?;
     m.add_wrapped(wrap_pymodule!(experiment::experiment))?;
+    m.add_wrapped(wrap_pymodule!(app::app))?;
 
     // types
     m.add_wrapped(wrap_pymodule!(types::types))?;

--- a/py-opsml/tests/api/assets/pyproject.toml
+++ b/py-opsml/tests/api/assets/pyproject.toml
@@ -7,22 +7,20 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 
-[tool.opsml.default]
-space = "space"
 
 [tool.opsml.registry]
-model = { name = "model" }
+model = { space="model-space", name = "model-name" }
 
 [[tool.opsml.deck]]
-space = "space"
-name = "name"
+space = "opsml-space"
+name = "opsml-name"
 version = "1"
 write_dir = "opsml_app"
 
 [[tool.opsml.deck.cards]]
 alias = "model"
-space = "space"
-name = "name"
+space = "model-space"
+name = "model-name"
 version = "1"
 type = "model"
 drift = { active = true, deactivate_others = false, drift_type = ["psi"] }

--- a/py-opsml/tests/api/assets/pyproject.toml
+++ b/py-opsml/tests/api/assets/pyproject.toml
@@ -1,0 +1,28 @@
+[project]
+name = "opsml-cli-test"
+requires-python = ">=3.10"
+classifiers = [
+    "Programming Language :: Rust",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Python :: Implementation :: PyPy",
+]
+
+[tool.opsml.default]
+space = "space"
+
+[tool.opsml.registry]
+model = { name = "model" }
+
+[[tool.opsml.deck]]
+space = "space"
+name = "name"
+version = "1"
+write_dir = "opsml_app"
+
+[[tool.opsml.deck.cards]]
+alias = "model"
+space = "space"
+name = "name"
+version = "1"
+type = "model"
+drift = { active = true, deactivate_others = false, drift_type = ["psi"] }

--- a/py-opsml/tests/api/conftest.py
+++ b/py-opsml/tests/api/conftest.py
@@ -8,19 +8,30 @@ from opsml.cli import (
     install_app,
 )  # type: ignore
 from pathlib import Path
-
+from fastapi import FastAPI, Request
 import os
-from typing import Generator
+from sklearn import ensemble  # type: ignore
+import pytest
+from typing import Generator, Dict, cast, Tuple, Union
 from opsml.mock import OpsmlTestServer
-from opsml.scouter import PsiDriftConfig
-
-
+from opsml.scouter import PsiDriftConfig, HTTPConfig
+import numpy as np
+from contextlib import asynccontextmanager
 from opsml import (  # type: ignore
     start_experiment,
     ModelCard,
 )
-from tests.conftest import random_forest_classifier, example_dataframe
+from opsml.helpers.data import create_fake_data  # type: ignore
+from sklearn.preprocessing import StandardScaler  # type: ignore
+from opsml import TaskType
+from opsml.model import SklearnModel
+import pandas as pd
+from numpy.typing import NDArray
+from opsml.app import AppState
 from pydantic import BaseModel
+from opsml.scouter.queue import Features, Feature, ScouterQueue
+
+# from opsml.scouter.queue import ScouterQueue
 from opsml.scouter.util import FeatureMixin
 
 # Set current directory
@@ -32,32 +43,96 @@ class TestResponse(BaseModel):
 
 
 class PredictRequest(BaseModel, FeatureMixin):
-    feature_0: float
-    feature_1: float
-    feature_2: float
-    feature_3: float
+    col_0: float
+    col_1: float
+    col_2: float
+    col_3: float
+    col_4: float
+    col_5: float
+    col_6: float
+    col_7: float
+    col_8: float
+    col_9: float
+
+    @staticmethod
+    def example_request() -> Dict[str, float]:
+        return {
+            "col_0": np.random.rand(),
+            "col_1": np.random.rand(),
+            "col_2": np.random.rand(),
+            "col_3": np.random.rand(),
+            "col_4": np.random.rand(),
+            "col_5": np.random.rand(),
+            "col_6": np.random.rand(),
+            "col_7": np.random.rand(),
+            "col_8": np.random.rand(),
+            "col_9": np.random.rand(),
+        }
+
+    def to_array(self) -> NDArray[np.float64]:
+        return np.array(
+            [
+                self.col_0,
+                self.col_1,
+                self.col_2,
+                self.col_3,
+                self.col_4,
+                self.col_5,
+                self.col_6,
+                self.col_7,
+                self.col_8,
+                self.col_9,
+            ]
+        ).reshape(1, -1)
 
 
-def run_experiment():
+def prediction_to_features(prediction: Union[int, float]) -> Features:
+    return Features(features=[Feature.float(name="target", value=prediction)])
+
+
+def example_dataframe() -> Tuple[pd.DataFrame, pd.DataFrame]:
+    X, y = cast(Tuple[pd.DataFrame, pd.DataFrame], create_fake_data(n_samples=1200))
+
+    return (X, y)
+
+
+def random_forest_classifier():
+    X_train, y_train = example_dataframe()
+    reg = ensemble.RandomForestClassifier(n_estimators=5)
+    reg.fit(X_train.to_numpy(), y_train)
+
+    return (
+        SklearnModel(
+            model=reg,
+            sample_data=X_train,
+            task_type=TaskType.Classification,
+            preprocessor=StandardScaler(),
+        ),
+        X_train,
+        y_train,
+    )
+
+
+def run_experiment() -> None:
     with start_experiment(space="test", log_hardware=True) as exp:
-        X, _, _, _ = example_dataframe()
-        classifier = random_forest_classifier()
+        classifier, X, y = random_forest_classifier()
         # create psi drift profile
         classifier.create_drift_profile(
             alias="psi",
-            data=X,
+            data=y,
             config=PsiDriftConfig(),
         )
 
         modelcard = ModelCard(
-            interface=random_forest_classifier,
+            interface=classifier,
             tags=["foo:bar", "baz:qux"],
             version="1.0.0",
         )
         exp.register_card(modelcard)
 
 
-def create_artifacts() -> Generator[Path, None, None]:
+@pytest.fixture
+def create_artifacts() -> Generator[Tuple[Path, Path], None, None]:
     with OpsmlTestServer(True, CURRENT_DIRECTORY):
         run_experiment()
         lock_project(CURRENT_DIRECTORY)
@@ -71,4 +146,42 @@ def create_artifacts() -> Generator[Path, None, None]:
         opsml_app = CURRENT_DIRECTORY / "opsml_app"
         assert opsml_app.exists()
 
-        yield opsml_app
+        # Check if the lock file was created
+        lock_file = CURRENT_DIRECTORY / "opsml.lock"
+        assert lock_file.exists()
+
+        yield opsml_app, lock_file
+
+
+def create_app(opsml_app: Path) -> FastAPI:
+    config = HTTPConfig()
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        app_state = AppState.from_path(
+            path=opsml_app,
+            transport_config=config,
+        )
+        app.state.app_state = app_state
+
+        yield
+
+        # Shutdown the queue
+        app.state.app_state.queue.shutdown()
+
+    app = FastAPI(lifespan=lifespan)
+
+    @app.post("/predict", response_model=TestResponse)
+    async def predict(request: Request, payload: PredictRequest) -> TestResponse:
+        modelcard: ModelCard = request.app.state.app_state.deck["model"]
+        queue: ScouterQueue = request.app.state.app_state.queue
+
+        # make prediction
+        prediction = modelcard.model.predict(payload.to_array())
+
+        # Send to queue
+        queue["psi"].insert(prediction_to_features(prediction[0]))
+
+        return TestResponse(message="success")
+
+    return app

--- a/py-opsml/tests/api/conftest.py
+++ b/py-opsml/tests/api/conftest.py
@@ -1,0 +1,74 @@
+###################################################################################################
+# This file contains test cases for testing an OpsML App workflow in an api with an http queue
+# This is an integration test and will require running the scouter-server docker image in the background.
+###################################################################################################
+
+from opsml.cli import (
+    lock_project,
+    install_app,
+)  # type: ignore
+from pathlib import Path
+
+import os
+from typing import Generator
+from opsml.mock import OpsmlTestServer
+from opsml.scouter import PsiDriftConfig
+
+
+from opsml import (  # type: ignore
+    start_experiment,
+    ModelCard,
+)
+from tests.conftest import random_forest_classifier, example_dataframe
+from pydantic import BaseModel
+from opsml.scouter.util import FeatureMixin
+
+# Set current directory
+CURRENT_DIRECTORY = Path(os.getcwd()) / "tests" / "api" / "assets"
+
+
+class TestResponse(BaseModel):
+    message: str
+
+
+class PredictRequest(BaseModel, FeatureMixin):
+    feature_0: float
+    feature_1: float
+    feature_2: float
+    feature_3: float
+
+
+def run_experiment():
+    with start_experiment(space="test", log_hardware=True) as exp:
+        X, _, _, _ = example_dataframe()
+        classifier = random_forest_classifier()
+        # create psi drift profile
+        classifier.create_drift_profile(
+            alias="psi",
+            data=X,
+            config=PsiDriftConfig(),
+        )
+
+        modelcard = ModelCard(
+            interface=random_forest_classifier,
+            tags=["foo:bar", "baz:qux"],
+            version="1.0.0",
+        )
+        exp.register_card(modelcard)
+
+
+def create_artifacts() -> Generator[Path, None, None]:
+    with OpsmlTestServer(True, CURRENT_DIRECTORY):
+        run_experiment()
+        lock_project(CURRENT_DIRECTORY)
+
+        lock_file = CURRENT_DIRECTORY / "opsml.lock"
+        assert lock_file.exists()
+
+        # download the assets
+        install_app(CURRENT_DIRECTORY, CURRENT_DIRECTORY)
+
+        opsml_app = CURRENT_DIRECTORY / "opsml_app"
+        assert opsml_app.exists()
+
+        yield opsml_app

--- a/py-opsml/tests/api/test_api.py
+++ b/py-opsml/tests/api/test_api.py
@@ -1,60 +1,25 @@
-import time
-
 from fastapi.testclient import TestClient
-from scouter.client import DriftRequest, ScouterClient, TimeInterval
-from scouter.types import DriftType
-
-from tests.integration.api.conftest import PredictRequest
-
-from .conftest import create_and_register_drift_profile, create_app
+from tests.api.conftest import PredictRequest, create_app
+import shutil
+import os
 
 
-def test_api_kafka(create_artifacts):
+def test_api(create_artifacts):
     # create the client
-    scouter_client = ScouterClient()
+    opsml_app, lock_file = create_artifacts
 
-    # create the drift profile
-    profile = create_and_register_drift_profile(client=scouter_client)
-    drift_path = profile.save_to_json()
-
-    # Create FastAPI app
-    app = create_app(drift_path)
+    # create fastapi app
+    fastapi_app = create_app(opsml_app)
 
     # Configure the TestClient
-    with TestClient(app) as client:
+    with TestClient(fastapi_app) as client:
         # Simulate requests
         for _ in range(60):
             response = client.post(
                 "/predict",
-                json=PredictRequest(
-                    feature_0=1.0,
-                    feature_1=1.0,
-                    feature_2=1.0,
-                    feature_3=1.0,
-                ).model_dump(),
+                json=PredictRequest.example_request(),
             )
         assert response.status_code == 200
 
-    time.sleep(10)
-
-    request = DriftRequest(
-        name=profile.config.name,
-        space=profile.config.space,
-        version=profile.config.version,
-        time_interval=TimeInterval.FiveMinutes,
-        max_data_points=100,
-        drift_type=DriftType.Spc,
-    )
-
-    drift = scouter_client.get_binned_drift(request)
-
-    assert drift.features.keys() == {
-        "feature_0",
-        "feature_1",
-        "feature_2",
-        "feature_3",
-    }
-    assert len(drift.features["feature_0"].values) == 1
-
-    # delete the drift_path
-    drift_path.unlink()
+    shutil.rmtree(opsml_app)
+    os.remove(lock_file)

--- a/py-opsml/tests/api/test_api.py
+++ b/py-opsml/tests/api/test_api.py
@@ -1,0 +1,60 @@
+import time
+
+from fastapi.testclient import TestClient
+from scouter.client import DriftRequest, ScouterClient, TimeInterval
+from scouter.types import DriftType
+
+from tests.integration.api.conftest import PredictRequest
+
+from .conftest import create_and_register_drift_profile, create_app
+
+
+def test_api_kafka(create_artifacts):
+    # create the client
+    scouter_client = ScouterClient()
+
+    # create the drift profile
+    profile = create_and_register_drift_profile(client=scouter_client)
+    drift_path = profile.save_to_json()
+
+    # Create FastAPI app
+    app = create_app(drift_path)
+
+    # Configure the TestClient
+    with TestClient(app) as client:
+        # Simulate requests
+        for _ in range(60):
+            response = client.post(
+                "/predict",
+                json=PredictRequest(
+                    feature_0=1.0,
+                    feature_1=1.0,
+                    feature_2=1.0,
+                    feature_3=1.0,
+                ).model_dump(),
+            )
+        assert response.status_code == 200
+
+    time.sleep(10)
+
+    request = DriftRequest(
+        name=profile.config.name,
+        space=profile.config.space,
+        version=profile.config.version,
+        time_interval=TimeInterval.FiveMinutes,
+        max_data_points=100,
+        drift_type=DriftType.Spc,
+    )
+
+    drift = scouter_client.get_binned_drift(request)
+
+    assert drift.features.keys() == {
+        "feature_0",
+        "feature_1",
+        "feature_2",
+        "feature_3",
+    }
+    assert len(drift.features["feature_0"].values) == 1
+
+    # delete the drift_path
+    drift_path.unlink()

--- a/py-opsml/tests/cli/test_app.py
+++ b/py-opsml/tests/cli/test_app.py
@@ -1,0 +1,118 @@
+###################################################################################################
+# This file contains test cases for testing an OpsML App workflow
+###################################################################################################
+
+from opsml.cli import (
+    lock_project,
+    install_app,
+)  # type: ignore
+
+import pandas as pd
+import os
+from pathlib import Path
+import shutil
+from opsml.mock import OpsmlTestServer
+from opsml.scouter import (
+    PsiDriftConfig,
+    CustomMetricDriftConfig,
+    CustomMetric,
+    HTTPConfig,
+)
+from opsml.scouter.alert import AlertThreshold
+from opsml.app import AppState
+
+
+from opsml import (  # type: ignore
+    start_experiment,
+    ModelCard,
+    SklearnModel,
+    PromptCard,
+    Prompt,
+)
+from tests.conftest import WINDOWS_EXCLUDE
+import pytest
+
+# Set current directory
+CURRENT_DIRECTORY = Path(os.getcwd()) / "tests" / "cli" / "assets"
+
+
+def run_experiment(
+    random_forest_classifier: SklearnModel,
+    chat_prompt: Prompt,
+    example_dataframe: pd.DataFrame,
+):
+    with start_experiment(space="test", log_hardware=True) as exp:
+        X, _, _, _ = example_dataframe
+        # create psi drift profile
+        random_forest_classifier.create_drift_profile(
+            alias="psi",
+            data=X,
+            config=PsiDriftConfig(),
+        )
+
+        # create custom metric drift profile
+        metric = CustomMetric(
+            name="custom",
+            value=0.5,
+            alert_threshold=AlertThreshold.Above,
+        )
+
+        random_forest_classifier.create_drift_profile(
+            alias="custom",
+            data=[metric],
+            config=CustomMetricDriftConfig(),
+        )
+
+        modelcard = ModelCard(
+            interface=random_forest_classifier,
+            tags=["foo:bar", "baz:qux"],
+            version="1.0.0",
+        )
+        exp.register_card(modelcard)
+
+        prompt_card = PromptCard(
+            prompt=chat_prompt,
+            version="1.0.0",
+        )
+        exp.register_card(prompt_card)
+
+
+@pytest.mark.skipif(WINDOWS_EXCLUDE, reason="skipping")
+def test_pyproject_app(
+    random_forest_classifier: SklearnModel,
+    chat_prompt: Prompt,
+    example_dataframe: pd.DataFrame,
+):
+    """
+    This test is meant to test the workflow of creating artifacts, creating a lock files, downloading
+    artifacts and loading them all from a path into an AppState object
+
+    """
+    with OpsmlTestServer(True, CURRENT_DIRECTORY):
+        # run experiment to populate registry
+        run_experiment(random_forest_classifier, chat_prompt, example_dataframe)
+
+        lock_project(CURRENT_DIRECTORY)
+
+        # Check if the lock file was created
+        lock_file = CURRENT_DIRECTORY / "opsml.lock"
+        assert lock_file.exists()
+
+        # download the assets
+        install_app(CURRENT_DIRECTORY, CURRENT_DIRECTORY)
+
+        # check if opsml_app was created
+        opsml_app = CURRENT_DIRECTORY / "opsml_app"
+        assert opsml_app.exists()
+
+        # check if the opsml_app contains the assets
+        assert (opsml_app / "app1").exists()
+
+        # load the card deck and the queue
+        app = AppState.from_path(path=opsml_app / "app1", transport_config=HTTPConfig())
+
+        assert app.queue is not None
+
+        ## delete the opsml_app and lock file
+        shutil.rmtree(opsml_app)
+        os.remove(lock_file)

--- a/py-opsml/uv.lock
+++ b/py-opsml/uv.lock
@@ -2470,7 +2470,7 @@ wheels = [
 
 [[package]]
 name = "opsml"
-version = "3.0.0rc8"
+version = "3.0.0rc9"
 source = { editable = "." }
 dependencies = [
     { name = "joblib" },


### PR DESCRIPTION
## Pull Request

### Summary
Additional helpers to aid in loading a `CardDeck` and `ScouterQueue` together. This is typically for Api  workflows.
- Adds `AppState` struct that can load a `CardDeck` and `ScouterQueue` in one call
- Adds `CardMapping` which contains paths to `CardDeck` cards and `Scouter` drift profile that are needed with the queues.
- This functionality will most likely be expanded in the future

