### PR TITLE
Separate registries

### DIFF
--- a/.github/workflows/lints-test.yml
+++ b/.github/workflows/lints-test.yml
@@ -31,6 +31,7 @@ jobs:
         run: |
           rustup override set stable && rustup update
           rustup component add clippy
+          rustup component add rustfmt
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/lints-test.yml
+++ b/.github/workflows/lints-test.yml
@@ -28,7 +28,9 @@ jobs:
           cmake-version: "3.x"
 
       - name: Set up Rust
-        run: rustup override set stable && rustup update
+        run: |
+          rustup override set stable && rustup update
+          rustup component add clippy
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2

--- a/crates/opsml_cli/src/cli/arg.rs
+++ b/crates/opsml_cli/src/cli/arg.rs
@@ -95,7 +95,6 @@ impl IntoQueryArgs for ListCards {
             tags: self.tags.clone(),
             max_date: self.max_date.clone(),
             sort_by_timestamp: Some(self.sort_by_timestamp),
-            service_type: self.service_type.clone(),
         })
     }
 }

--- a/crates/opsml_cli/src/error.rs
+++ b/crates/opsml_cli/src/error.rs
@@ -3,6 +3,7 @@ use opsml_crypt::error::CryptError;
 use opsml_registry::error::RegistryError;
 use opsml_storage::storage::error::StorageError;
 use opsml_toml::error::PyProjectTomlError;
+use opsml_types::contracts::ServiceType;
 use opsml_types::error::TypeError;
 use opsml_utils::error::PyUtilError;
 use opsml_utils::error::UtilError;
@@ -76,6 +77,9 @@ pub enum CliError {
 
     #[error(transparent)]
     ServiceError(#[from] opsml_service::error::ServiceError),
+
+    #[error("Unsupported service type: {0:?}")]
+    UnsupportedServiceType(ServiceType),
 }
 
 impl From<CliError> for PyErr {

--- a/crates/opsml_genai/src/mcp.rs
+++ b/crates/opsml_genai/src/mcp.rs
@@ -19,7 +19,7 @@ pub fn list_mcp_servers(
         space: space.clone(),
         name: name.clone(),
         tags: tags.clone(),
-        service_type: Some(ServiceType::Mcp.to_string()),
+        service_type: ServiceType::Mcp,
     };
 
     let servers = registry

--- a/crates/opsml_registry/src/registry.rs
+++ b/crates/opsml_registry/src/registry.rs
@@ -119,7 +119,6 @@ impl CardRegistry {
         max_date=None,
         tags=None,
         sort_by_timestamp=None,
-        service_type=None,
         limit=100
     ))]
     #[instrument(skip_all)]
@@ -132,7 +131,6 @@ impl CardRegistry {
         max_date: Option<String>,
         tags: Option<Vec<String>>,
         sort_by_timestamp: Option<bool>,
-        service_type: Option<ServiceType>,
         limit: i32,
     ) -> Result<CardList, RegistryError> {
         debug!(
@@ -153,7 +151,6 @@ impl CardRegistry {
             tags,
             limit: Some(limit),
             sort_by_timestamp,
-            service_type: service_type.map(|s| s.to_string()),
             registry_type: self.registry_type.clone(),
         };
 
@@ -817,6 +814,9 @@ pub struct CardRegistries {
 
     #[pyo3(get)]
     pub service: CardRegistry,
+
+    #[pyo3(get)]
+    pub mcp: CardRegistry,
 }
 
 #[pymethods]
@@ -835,6 +835,7 @@ impl CardRegistries {
         let data = CardRegistry::rust_new(&RegistryType::Data)?;
         let prompt = CardRegistry::rust_new(&RegistryType::Prompt)?;
         let service = CardRegistry::rust_new(&RegistryType::Service)?;
+        let mcp = CardRegistry::rust_new(&RegistryType::Mcp)?;
 
         Ok(Self {
             experiment,
@@ -842,6 +843,7 @@ impl CardRegistries {
             data,
             prompt,
             service,
+            mcp,
         })
     }
 }

--- a/crates/opsml_server/tests/api/card.rs
+++ b/crates/opsml_server/tests/api/card.rs
@@ -254,7 +254,6 @@ async fn test_opsml_server_card_list_cards() {
         tags: None,
         limit: None,
         sort_by_timestamp: None,
-        service_type: None,
         registry_type: RegistryType::Data,
     };
 
@@ -283,7 +282,6 @@ async fn test_opsml_server_card_list_cards() {
         tags: None,
         limit: None,
         sort_by_timestamp: None,
-        service_type: None,
         registry_type: RegistryType::Model,
     };
 
@@ -1029,7 +1027,7 @@ async fn test_opsml_server_card_service_card_mcps() {
             deployment: Some(vec![deploy]),
             ..ServiceCardClientRecord::default()
         }),
-        registry_type: RegistryType::Service,
+        registry_type: RegistryType::Mcp,
         version_request: card_version_request,
     };
 
@@ -1051,7 +1049,7 @@ async fn test_opsml_server_card_service_card_mcps() {
 
     // list mcp services
     let list_mcps = ServiceQueryArgs {
-        service_type: Some(ServiceType::Mcp.to_string()),
+        service_type: ServiceType::Mcp,
         ..Default::default()
     };
 
@@ -1256,7 +1254,6 @@ async fn test_opsml_server_card_get_card() {
         tags: None,
         limit: None,
         sort_by_timestamp: None,
-        service_type: None,
         registry_type: RegistryType::Model,
     };
     //
@@ -1317,7 +1314,6 @@ async fn test_opsml_server_card_get_readme() {
         tags: None,
         limit: None,
         sort_by_timestamp: None,
-        service_type: None,
         registry_type: RegistryType::Model,
     };
     //

--- a/crates/opsml_sql/src/mysql/client.rs
+++ b/crates/opsml_sql/src/mysql/client.rs
@@ -1254,10 +1254,66 @@ mod tests {
     #[tokio::test]
     async fn test_mysql_recent_services() {
         let client = db_client().await;
+        // create 1st service card
+        let service1 = ServiceCardRecord {
+            name: "Service1".to_string(),
+            space: SPACE.to_string(),
+            service_type: ServiceType::Api.to_string(),
+            tags: Json(vec!["tag1".to_string()]),
+            ..Default::default()
+        };
+        client
+            .card
+            .insert_card(&CardTable::Service, &ServerCard::Service(service1))
+            .await
+            .unwrap();
+
+        // create 2nd card
+        let service2 = ServiceCardRecord {
+            name: "Service2".to_string(),
+            space: SPACE.to_string(),
+            service_type: ServiceType::Api.to_string(),
+            ..Default::default()
+        };
+        client
+            .card
+            .insert_card(&CardTable::Service, &ServerCard::Service(service2))
+            .await
+            .unwrap();
+
+        let services = client
+            .card
+            .get_recent_services(&ServiceQueryArgs {
+                space: None,
+                name: None,
+                tags: None,
+                service_type: ServiceType::Api,
+            })
+            .await
+            .unwrap();
+        assert_eq!(services.len(), 2);
+
+        // search by tag
+        let services = client
+            .card
+            .get_recent_services(&ServiceQueryArgs {
+                space: None,
+                name: None,
+                tags: Some(vec!["tag1".to_string()]),
+                service_type: ServiceType::Api,
+            })
+            .await
+            .unwrap();
+        assert_eq!(services.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_mysql_recent_mcp_services() {
+        let client = db_client().await;
 
         // create 1st service card
-        let card1 = ServiceCardRecord {
-            name: "Service0".to_string(),
+        let mcp1 = ServiceCardRecord {
+            name: "mcp1".to_string(),
             space: SPACE.to_string(),
             service_type: ServiceType::Mcp.to_string(),
             tags: Json(vec!["tag1".to_string()]),
@@ -1265,20 +1321,20 @@ mod tests {
         };
         client
             .card
-            .insert_card(&CardTable::Service, &ServerCard::Service(card1))
+            .insert_card(&CardTable::Mcp, &ServerCard::Service(mcp1))
             .await
             .unwrap();
 
         // create 2nd card
-        let card2 = ServiceCardRecord {
-            name: "Service1".to_string(),
+        let mcp2 = ServiceCardRecord {
+            name: "mcp2".to_string(),
             space: SPACE.to_string(),
-            service_type: ServiceType::Api.to_string(),
+            service_type: ServiceType::Mcp.to_string(),
             ..Default::default()
         };
         client
             .card
-            .insert_card(&CardTable::Service, &ServerCard::Service(card2))
+            .insert_card(&CardTable::Mcp, &ServerCard::Service(mcp2))
             .await
             .unwrap();
 
@@ -1300,8 +1356,8 @@ mod tests {
             }),
             links: None,
         };
-        let card3 = ServiceCardRecord {
-            name: "Service0".to_string(),
+        let mcp3 = ServiceCardRecord {
+            name: "mcp1".to_string(),
             space: SPACE.to_string(),
             service_type: ServiceType::Mcp.to_string(),
             tags: Json(vec!["tag1".to_string()]),
@@ -1312,11 +1368,12 @@ mod tests {
             deployment: Some(Json(vec![deploy])),
             ..Default::default()
         };
+
         // wait 1 second to ensure different created_at timestamp
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
         client
             .card
-            .insert_card(&CardTable::Service, &ServerCard::Service(card3))
+            .insert_card(&CardTable::Mcp, &ServerCard::Service(mcp3))
             .await
             .unwrap();
 
@@ -1326,7 +1383,7 @@ mod tests {
                 space: None,
                 name: None,
                 tags: None,
-                service_type: None,
+                service_type: ServiceType::Mcp,
             })
             .await
             .unwrap();
@@ -1339,19 +1396,7 @@ mod tests {
                 space: None,
                 name: None,
                 tags: Some(vec!["tag1".to_string()]),
-                service_type: None,
-            })
-            .await
-            .unwrap();
-        assert_eq!(services.len(), 1);
-
-        let services = client
-            .card
-            .get_recent_services(&ServiceQueryArgs {
-                space: None,
-                name: None,
-                tags: None,
-                service_type: Some(ServiceType::Mcp.to_string()),
+                service_type: ServiceType::Mcp,
             })
             .await
             .unwrap();

--- a/crates/opsml_sql/src/mysql/migrations/20250924234947_mcp_registry.sql
+++ b/crates/opsml_sql/src/mysql/migrations/20250924234947_mcp_registry.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS opsml_mcp_registry (
+    uid VARCHAR(64) PRIMARY KEY,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    app_env VARCHAR(32) DEFAULT 'development',
+    space VARCHAR(255),
+    name VARCHAR(255),
+    major INT NOT NULL,
+    minor INT NOT NULL,
+    patch INT NOT NULL,
+    pre_tag VARCHAR(255),
+    build_tag VARCHAR(255),
+    version VARCHAR(255),
+    cards JSON NOT NULL DEFAULT ('[]'),
+    opsml_version VARCHAR(255) NOT NULL DEFAULT '0.0.0',
+    username VARCHAR(255) NOT NULL DEFAULT 'guest',
+    service_type VARCHAR(32) NOT NULL DEFAULT 'api',
+    metadata JSON,
+    deployment JSON,
+    service_config JSON,
+    tags JSON
+);

--- a/crates/opsml_sql/src/mysql/sql/card/insert_mcp_servicecard.sql
+++ b/crates/opsml_sql/src/mysql/sql/card/insert_mcp_servicecard.sql
@@ -1,0 +1,20 @@
+INSERT INTO opsml_mcp_registry (
+    uid, 
+    app_env, 
+    name, 
+    space, 
+    major, 
+    minor, 
+    patch, 
+    version, 
+    pre_tag, 
+    build_tag, 
+    cards, 
+    username, 
+    opsml_version, 
+    service_type,
+    metadata,
+    deployment,
+    service_config,
+    tags
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);

--- a/crates/opsml_sql/src/mysql/sql/card/update_mcp_servicecard.sql
+++ b/crates/opsml_sql/src/mysql/sql/card/update_mcp_servicecard.sql
@@ -1,0 +1,17 @@
+UPDATE opsml_mcp_registry SET 
+    app_env = ?, 
+    name = ?, 
+    space = ?, 
+    major = ?, 
+    minor = ?, 
+    patch = ?, 
+    version = ?, 
+    cards = ?,
+    username = ?,
+    opsml_version = ?,
+    service_type = ?,
+    metadata = ?,
+    deployment = ?,
+    service_config = ?,
+    tags = ?
+WHERE uid = ?;

--- a/crates/opsml_sql/src/postgres/helper.rs
+++ b/crates/opsml_sql/src/postgres/helper.rs
@@ -650,12 +650,12 @@ impl PostgresQueryHelper {
     }
 
     pub fn get_recent_services_query(query_args: &ServiceQueryArgs) -> String {
+        let card_table = CardTable::from_service_type(&query_args.service_type);
         let mut where_clause = String::from(
             "
         WHERE 1=1
         AND ($1 IS NULL OR space = $1)
         AND ($2 IS NULL OR name = $2)
-        AND ($3 IS NULL OR service_type = $3)
     ",
         );
 
@@ -676,7 +676,7 @@ impl PostgresQueryHelper {
                     PARTITION BY space, name
                     ORDER BY created_at DESC
                 ) AS rn
-            FROM opsml_service_registry
+            FROM {card_table}
             {where_clause}
         )
         WHERE rn = 1;

--- a/crates/opsml_sql/src/postgres/helper.rs
+++ b/crates/opsml_sql/src/postgres/helper.rs
@@ -413,7 +413,7 @@ impl PostgresQueryHelper {
             query.push_str(" ORDER BY major DESC, minor DESC, patch DESC");
         }
 
-        query.push_str(&format!(" LIMIT $5"));
+        query.push_str(" LIMIT $5");
 
         Ok(query)
     }

--- a/crates/opsml_sql/src/postgres/helper.rs
+++ b/crates/opsml_sql/src/postgres/helper.rs
@@ -43,12 +43,14 @@ const INSERT_MODELCARD_SQL: &str = include_str!("sql/card/insert_modelcard.sql")
 const INSERT_EXPERIMENTCARD_SQL: &str = include_str!("sql/card/insert_experimentcard.sql");
 const INSERT_AUDITCARD_SQL: &str = include_str!("sql/card/insert_auditcard.sql");
 const INSERT_SERVICECARD_SQL: &str = include_str!("sql/card/insert_servicecard.sql");
+const INSERT_MCP_SERVICECARD_SQL: &str = include_str!("sql/card/insert_mcp_servicecard.sql");
 const UPDATE_DATACARD_SQL: &str = include_str!("sql/card/update_datacard.sql");
 const UPDATE_PROMPTCARD_SQL: &str = include_str!("sql/card/update_promptcard.sql");
 const UPDATE_MODELCARD_SQL: &str = include_str!("sql/card/update_modelcard.sql");
 const UPDATE_EXPERIMENTCARD_SQL: &str = include_str!("sql/card/update_experimentcard.sql");
 const UPDATE_AUDITCARD_SQL: &str = include_str!("sql/card/update_auditcard.sql");
 const UPDATE_SERVICECARD_SQL: &str = include_str!("sql/card/update_servicecard.sql");
+const UPDATE_MCP_SERVICECARD_SQL: &str = include_str!("sql/card/update_mcp_servicecard.sql");
 
 // artifact keys
 const INSERT_ARTIFACT_KEY_SQL: &str = include_str!("sql/artifact/insert_artifact_key.sql");
@@ -364,7 +366,6 @@ impl PostgresQueryHelper {
         table: &CardTable,
         query_args: &CardQueryArgs,
     ) -> Result<String, SqlError> {
-        let mut binding_index = 5; // Start from 2 because $1 is used for space
         if query_args.uid.is_some() {
             is_valid_uuidv7(query_args.uid.as_ref().unwrap())?;
             return Ok(format!("SELECT * FROM {table} WHERE uid = $1 LIMIT 1"));
@@ -391,11 +392,6 @@ impl PostgresQueryHelper {
             query.push_str(" AND created_at <= TO_DATE($4, 'YYYY-MM-DD')");
         }
 
-        if query_args.service_type.is_some() {
-            query.push_str(" AND service_type = $5");
-            binding_index += 1;
-        }
-
         // Add version bounds - will use the version part of the index
         if query_args.version.is_some() {
             add_version_bounds(&mut query, query_args.version.as_ref().unwrap())?;
@@ -417,7 +413,7 @@ impl PostgresQueryHelper {
             query.push_str(" ORDER BY major DESC, minor DESC, patch DESC");
         }
 
-        query.push_str(&format!(" LIMIT ${binding_index}"));
+        query.push_str(&format!(" LIMIT $5"));
 
         Ok(query)
     }
@@ -535,12 +531,20 @@ impl PostgresQueryHelper {
         INSERT_AUDITCARD_SQL.to_string()
     }
 
-    pub fn get_servicecard_insert_query() -> String {
-        INSERT_SERVICECARD_SQL.to_string()
+    pub fn get_servicecard_insert_query(table: &CardTable) -> String {
+        match table {
+            CardTable::Service => INSERT_SERVICECARD_SQL.to_string(),
+            CardTable::Mcp => INSERT_MCP_SERVICECARD_SQL.to_string(),
+            _ => INSERT_SERVICECARD_SQL.to_string(),
+        }
     }
 
-    pub fn get_servicecard_update_query() -> String {
-        UPDATE_SERVICECARD_SQL.to_string()
+    pub fn get_servicecard_update_query(table: &CardTable) -> String {
+        match table {
+            CardTable::Service => UPDATE_SERVICECARD_SQL.to_string(),
+            CardTable::Mcp => UPDATE_MCP_SERVICECARD_SQL.to_string(),
+            _ => UPDATE_SERVICECARD_SQL.to_string(),
+        }
     }
 
     pub fn get_promptcard_update_query() -> String {

--- a/crates/opsml_sql/src/postgres/migrations/20250924234751_mcp_registry.sql
+++ b/crates/opsml_sql/src/postgres/migrations/20250924234751_mcp_registry.sql
@@ -1,0 +1,25 @@
+-- Add migration script here
+CREATE TABLE IF NOT EXISTS opsml_mcp_registry (
+    uid TEXT PRIMARY KEY,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    app_env TEXT DEFAULT 'development',
+    space TEXT,
+    name TEXT,
+    major INTEGER NOT NULL,
+    minor INTEGER NOT NULL,
+    patch INTEGER NOT NULL,
+    pre_tag TEXT,
+    build_tag TEXT,
+    version TEXT,
+    cards JSONB NOT NULL DEFAULT '[]',
+    opsml_version TEXT NOT NULL DEFAULT '0.0.0',
+    username TEXT NOT NULL DEFAULT 'guest',
+    service_type TEXT NOT NULL DEFAULT 'mcp',
+    metadata JSONB,
+    deployment JSONB,
+    service_config JSONB,
+    tags JSONB DEFAULT '[]'
+);
+
+CREATE INDEX idx_opsml_mcp_registry_space_name ON opsml_mcp_registry (space, name);
+CREATE INDEX idx_opsml_mcp_registry_uid ON opsml_mcp_registry (uid);

--- a/crates/opsml_sql/src/postgres/sql/card/insert_mcp_servicecard.sql
+++ b/crates/opsml_sql/src/postgres/sql/card/insert_mcp_servicecard.sql
@@ -1,0 +1,21 @@
+INSERT INTO opsml_mcp_registry (
+    uid, 
+    app_env, 
+    name, 
+    space, 
+    major, 
+    minor, 
+    patch, 
+    version,
+    pre_tag, 
+    build_tag, 
+    cards, 
+    username, 
+    opsml_version,
+    service_type,
+    metadata,
+    deployment,
+    service_config,
+    tags
+    ) 
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18);

--- a/crates/opsml_sql/src/postgres/sql/card/mod.rs
+++ b/crates/opsml_sql/src/postgres/sql/card/mod.rs
@@ -708,7 +708,6 @@ impl CardLogicTrait for CardLogicPostgresClient {
         let records: Vec<ServiceCardRecord> = sqlx::query_as(&query)
             .bind(query_args.space.as_ref())
             .bind(query_args.name.as_ref())
-            .bind(query_args.service_type.as_ref())
             .fetch_all(&self.pool)
             .await?;
 

--- a/crates/opsml_sql/src/postgres/sql/card/update_mcp_servicecard.sql
+++ b/crates/opsml_sql/src/postgres/sql/card/update_mcp_servicecard.sql
@@ -1,0 +1,17 @@
+UPDATE opsml_mcp_registry SET 
+app_env = $1, 
+name = $2,
+space = $3,
+major = $4, 
+minor = $5,
+patch = $6, 
+version = $7, 
+cards = $8,
+username = $9,
+opsml_version = $10,
+service_type = $11,
+metadata = $12,
+deployment = $13,
+service_config = $14,
+tags = $15
+WHERE uid = $16;

--- a/crates/opsml_sql/src/sqlite/client.rs
+++ b/crates/opsml_sql/src/sqlite/client.rs
@@ -1269,7 +1269,7 @@ mod tests {
         };
         client
             .card
-            .insert_card(&CardTable::Mcp, &ServerCard::Service(card1))
+            .insert_card(&CardTable::Service, &ServerCard::Service(card1))
             .await
             .unwrap();
 

--- a/crates/opsml_sql/src/sqlite/client.rs
+++ b/crates/opsml_sql/src/sqlite/client.rs
@@ -1261,21 +1261,21 @@ mod tests {
 
         // create 1st service card
         let card1 = ServiceCardRecord {
-            name: "Service0".to_string(),
+            name: "ApiService1".to_string(),
             space: SPACE.to_string(),
-            service_type: ServiceType::Mcp.to_string(),
+            service_type: ServiceType::Api.to_string(),
             tags: Json(vec!["tag1".to_string()]),
             ..Default::default()
         };
         client
             .card
-            .insert_card(&CardTable::Service, &ServerCard::Service(card1))
+            .insert_card(&CardTable::Mcp, &ServerCard::Service(card1))
             .await
             .unwrap();
 
         // create 2nd card
         let card2 = ServiceCardRecord {
-            name: "Service1".to_string(),
+            name: "ApiService2".to_string(),
             space: SPACE.to_string(),
             service_type: ServiceType::Api.to_string(),
             ..Default::default()
@@ -1285,6 +1285,46 @@ mod tests {
             .insert_card(&CardTable::Service, &ServerCard::Service(card2))
             .await
             .unwrap();
+
+        let services = client
+            .card
+            .get_recent_services(&ServiceQueryArgs {
+                space: None,
+                name: None,
+                tags: None,
+                service_type: ServiceType::Api,
+            })
+            .await
+            .unwrap();
+        assert_eq!(services.len(), 2);
+
+        // search by tag
+        let services = client
+            .card
+            .get_recent_services(&ServiceQueryArgs {
+                space: None,
+                name: None,
+                tags: Some(vec!["tag1".to_string()]),
+                service_type: ServiceType::Api,
+            })
+            .await
+            .unwrap();
+        assert_eq!(services.len(), 1);
+
+        cleanup();
+    }
+
+    #[tokio::test]
+    async fn test_sqlite_recent_mcp_services() {
+        cleanup();
+
+        let config = DatabaseSettings {
+            connection_uri: get_connection_uri(),
+            max_connections: 1,
+            sql_type: SqlType::Sqlite,
+        };
+
+        let client = SqliteClient::new(&config).await.unwrap();
 
         // Create 3rd card, but new version
         let mcp_config = McpConfig {
@@ -1304,8 +1344,30 @@ mod tests {
             }),
             links: None,
         };
-        let card3 = ServiceCardRecord {
-            name: "Service0".to_string(),
+        let mcp_card1 = ServiceCardRecord {
+            name: "mcp1".to_string(),
+            space: SPACE.to_string(),
+            service_type: ServiceType::Mcp.to_string(),
+            tags: Json(vec!["tag1".to_string()]),
+            service_config: Json(ServiceConfig {
+                mcp: Some(mcp_config.clone()),
+                ..Default::default()
+            }),
+            deployment: Some(Json(vec![deploy.clone()])),
+            ..Default::default()
+        };
+
+        client
+            .card
+            .insert_card(&CardTable::Mcp, &ServerCard::Service(mcp_card1))
+            .await
+            .unwrap();
+
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        // create new version
+        let mcp_card2 = ServiceCardRecord {
+            name: "mcp1".to_string(),
             space: SPACE.to_string(),
             service_type: ServiceType::Mcp.to_string(),
             tags: Json(vec!["tag1".to_string()]),
@@ -1316,11 +1378,10 @@ mod tests {
             deployment: Some(Json(vec![deploy])),
             ..Default::default()
         };
-        // wait 1 second to ensure different created_at timestamp
-        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
         client
             .card
-            .insert_card(&CardTable::Service, &ServerCard::Service(card3))
+            .insert_card(&CardTable::Mcp, &ServerCard::Service(mcp_card2))
             .await
             .unwrap();
 
@@ -1330,32 +1391,7 @@ mod tests {
                 space: None,
                 name: None,
                 tags: None,
-                service_type: None,
-            })
-            .await
-            .unwrap();
-        assert_eq!(services.len(), 2);
-
-        // search by tag
-        let services = client
-            .card
-            .get_recent_services(&ServiceQueryArgs {
-                space: None,
-                name: None,
-                tags: Some(vec!["tag1".to_string()]),
-                service_type: None,
-            })
-            .await
-            .unwrap();
-        assert_eq!(services.len(), 1);
-
-        let services = client
-            .card
-            .get_recent_services(&ServiceQueryArgs {
-                space: None,
-                name: None,
-                tags: None,
-                service_type: Some(ServiceType::Mcp.to_string()),
+                service_type: ServiceType::Mcp,
             })
             .await
             .unwrap();

--- a/crates/opsml_sql/src/sqlite/helper.rs
+++ b/crates/opsml_sql/src/sqlite/helper.rs
@@ -42,12 +42,14 @@ const INSERT_MODELCARD_SQL: &str = include_str!("sql/card/insert_modelcard.sql")
 const INSERT_EXPERIMENTCARD_SQL: &str = include_str!("sql/card/insert_experimentcard.sql");
 const INSERT_AUDITCARD_SQL: &str = include_str!("sql/card/insert_auditcard.sql");
 const INSERT_SERVICECARD_SQL: &str = include_str!("sql/card/insert_servicecard.sql");
+const INSERT_MCP_SERVICECARD_SQL: &str = include_str!("sql/card/insert_mcp_servicecard.sql");
 const UPDATE_DATACARD_SQL: &str = include_str!("sql/card/update_datacard.sql");
 const UPDATE_PROMPTCARD_SQL: &str = include_str!("sql/card/update_promptcard.sql");
 const UPDATE_MODELCARD_SQL: &str = include_str!("sql/card/update_modelcard.sql");
 const UPDATE_EXPERIMENTCARD_SQL: &str = include_str!("sql/card/update_experimentcard.sql");
 const UPDATE_AUDITCARD_SQL: &str = include_str!("sql/card/update_auditcard.sql");
 const UPDATE_SERVICECARD_SQL: &str = include_str!("sql/card/update_servicecard.sql");
+const UPDATE_MCP_SERVICECARD_SQL: &str = include_str!("sql/card/update_mcp_servicecard.sql");
 
 // evaluation
 const INSERT_EVALUATION_SQL: &str = include_str!("sql/evaluation/insert_evaluation.sql");
@@ -328,8 +330,6 @@ impl SqliteQueryHelper {
         table: &CardTable,
         query_args: &CardQueryArgs,
     ) -> Result<String, SqlError> {
-        let mut binding_index = 5;
-
         let mut query = format!(
             "
         SELECT * FROM {table}
@@ -340,12 +340,6 @@ impl SqliteQueryHelper {
         AND (?4 IS NULL OR created_at <= DATETIME(?4))
         "
         );
-
-        // if card table is Service, we can filter by service_type
-        if let CardTable::Service = table {
-            query.push_str(" AND (?5 IS NULL OR service_type = ?5) ");
-            binding_index += 1;
-        }
 
         // check for uid. If uid is present, we only return that card
         if query_args.uid.is_some() {
@@ -378,7 +372,7 @@ impl SqliteQueryHelper {
             }
         }
 
-        query.push_str(format!(" LIMIT ?{binding_index}").as_str());
+        query.push_str(format!(" LIMIT ?5").as_str());
 
         Ok(query)
     }
@@ -493,12 +487,20 @@ impl SqliteQueryHelper {
         INSERT_AUDITCARD_SQL.to_string()
     }
 
-    pub fn get_servicecard_insert_query() -> String {
-        INSERT_SERVICECARD_SQL.to_string()
+    pub fn get_servicecard_insert_query(table: &CardTable) -> String {
+        match table {
+            CardTable::Service => INSERT_SERVICECARD_SQL.to_string(),
+            CardTable::Mcp => INSERT_MCP_SERVICECARD_SQL.to_string(),
+            _ => INSERT_SERVICECARD_SQL.to_string(),
+        }
     }
 
-    pub fn get_servicecard_update_query() -> String {
-        UPDATE_SERVICECARD_SQL.to_string()
+    pub fn get_servicecard_update_query(table: &CardTable) -> String {
+        match table {
+            CardTable::Service => UPDATE_SERVICECARD_SQL.to_string(),
+            CardTable::Mcp => UPDATE_MCP_SERVICECARD_SQL.to_string(),
+            _ => UPDATE_SERVICECARD_SQL.to_string(),
+        }
     }
 
     pub fn get_promptcard_update_query() -> String {

--- a/crates/opsml_sql/src/sqlite/helper.rs
+++ b/crates/opsml_sql/src/sqlite/helper.rs
@@ -372,7 +372,7 @@ impl SqliteQueryHelper {
             }
         }
 
-        query.push_str(format!(" LIMIT ?5").as_str());
+        query.push_str(" LIMIT ?5");
 
         Ok(query)
     }

--- a/crates/opsml_sql/src/sqlite/helper.rs
+++ b/crates/opsml_sql/src/sqlite/helper.rs
@@ -607,12 +607,12 @@ impl SqliteQueryHelper {
     }
 
     pub fn get_recent_services_query(query_args: &ServiceQueryArgs) -> String {
+        let card_table = CardTable::from_service_type(&query_args.service_type);
         let mut where_clause = String::from(
             "
         WHERE 1=1
         AND (?1 IS NULL OR space = ?1)
         AND (?2 IS NULL OR name = ?2)
-        AND (?3 IS NULL OR service_type = ?3)
     ",
         );
 
@@ -634,7 +634,7 @@ impl SqliteQueryHelper {
                     PARTITION BY space, name
                     ORDER BY created_at DESC
                 ) AS rn
-            FROM opsml_service_registry
+            FROM {card_table}
             {where_clause}
         )
         WHERE rn = 1;

--- a/crates/opsml_sql/src/sqlite/migrations/20250924234524_mcp_registry.sql
+++ b/crates/opsml_sql/src/sqlite/migrations/20250924234524_mcp_registry.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS opsml_mcp_registry (
+    uid TEXT PRIMARY KEY,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    app_env TEXT DEFAULT 'development',
+    space TEXT,
+    name TEXT,
+    major INT NOT NULL,
+    minor INT NOT NULL,
+    patch INT NOT NULL,
+    pre_tag TEXT,
+    build_tag TEXT,
+    version TEXT,
+    cards TEXT DEFAULT '[]',
+    opsml_version TEXT NOT NULL DEFAULT '0.0.0',
+    username TEXT NOT NULL DEFAULT 'guest',
+    service_type TEXT NOT NULL DEFAULT 'mcp',
+    metadata TEXT,
+    deployment TEXT,
+    service_config TEXT,
+    tags TEXT
+);

--- a/crates/opsml_sql/src/sqlite/sql/card/insert_mcp_servicecard.sql
+++ b/crates/opsml_sql/src/sqlite/sql/card/insert_mcp_servicecard.sql
@@ -1,0 +1,22 @@
+INSERT INTO opsml_mcp_registry (
+    uid, 
+    app_env, 
+    name, 
+    space, 
+    major, 
+    minor, 
+    patch, 
+    version, 
+    pre_tag, 
+    build_tag, 
+    cards, 
+    username, 
+    opsml_version, 
+    service_type,
+    metadata,
+    deployment,
+    service_config,
+    tags
+    ) 
+    VALUES 
+    (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);

--- a/crates/opsml_sql/src/sqlite/sql/card/mod.rs
+++ b/crates/opsml_sql/src/sqlite/sql/card/mod.rs
@@ -728,7 +728,6 @@ impl CardLogicTrait for CardLogicSqliteClient {
         let records: Vec<ServiceCardRecord> = sqlx::query_as(&query)
             .bind(query_args.space.as_ref())
             .bind(query_args.name.as_ref())
-            .bind(query_args.service_type.as_ref())
             .fetch_all(&self.pool)
             .await?;
 

--- a/crates/opsml_sql/src/sqlite/sql/card/mod.rs
+++ b/crates/opsml_sql/src/sqlite/sql/card/mod.rs
@@ -171,13 +171,12 @@ impl CardLogicTrait for CardLogicSqliteClient {
                 return Ok(CardResults::Prompt(card));
             }
 
-            CardTable::Service => {
+            CardTable::Service | CardTable::Mcp => {
                 let card: Vec<ServiceCardRecord> = sqlx::query_as(&query)
                     .bind(query_args.uid.as_ref())
                     .bind(query_args.space.as_ref())
                     .bind(query_args.name.as_ref())
                     .bind(query_args.max_date.as_ref())
-                    .bind(query_args.service_type.as_ref())
                     .bind(query_args.limit.unwrap_or(1000))
                     .fetch_all(&self.pool)
                     .await?;
@@ -342,9 +341,9 @@ impl CardLogicTrait for CardLogicSqliteClient {
                     return Err(SqlError::InvalidCardType);
                 }
             },
-            CardTable::Service => match card {
+            CardTable::Service | CardTable::Mcp => match card {
                 ServerCard::Service(record) => {
-                    let query = SqliteQueryHelper::get_servicecard_insert_query();
+                    let query = SqliteQueryHelper::get_servicecard_insert_query(table);
                     sqlx::query(&query)
                         .bind(&record.uid)
                         .bind(&record.app_env)
@@ -531,9 +530,9 @@ impl CardLogicTrait for CardLogicSqliteClient {
                 }
             },
 
-            CardTable::Service => match card {
+            CardTable::Service | CardTable::Mcp => match card {
                 ServerCard::Service(record) => {
-                    let query = SqliteQueryHelper::get_servicecard_update_query();
+                    let query = SqliteQueryHelper::get_servicecard_update_query(table);
                     sqlx::query(&query)
                         .bind(&record.app_env)
                         .bind(&record.name)
@@ -702,18 +701,11 @@ impl CardLogicTrait for CardLogicSqliteClient {
     ) -> Result<ArtifactKey, SqlError> {
         let query = SqliteQueryHelper::get_load_card_query(table, query_args)?;
 
-        let mut bound = sqlx::query_as(&query)
+        let key: (String, String, String, Vec<u8>, String) = sqlx::query_as(&query)
             .bind(query_args.uid.as_ref())
             .bind(query_args.space.as_ref())
             .bind(query_args.name.as_ref())
-            .bind(query_args.max_date.as_ref());
-
-        // only bind if table is Service
-        if table == &CardTable::Service {
-            bound = bound.bind(query_args.service_type.as_ref());
-        }
-
-        let key: (String, String, String, Vec<u8>, String) = bound
+            .bind(query_args.max_date.as_ref())
             .bind(query_args.limit.unwrap_or(1))
             .fetch_one(&self.pool)
             .await?;

--- a/crates/opsml_sql/src/sqlite/sql/card/update_mcp_servicecard.sql
+++ b/crates/opsml_sql/src/sqlite/sql/card/update_mcp_servicecard.sql
@@ -1,0 +1,17 @@
+UPDATE opsml_mcp_registry SET 
+    app_env = ?, 
+    name = ?, 
+    space = ?, 
+    major = ?, 
+    minor = ?, 
+    patch = ?, 
+    version = ?, 
+    cards = ?,
+    username = ?,
+    opsml_version = ?,
+    service_type = ?,
+    metadata = ?,
+    deployment = ?,
+    service_config = ?,
+    tags = ?
+WHERE uid = ?;

--- a/crates/opsml_types/src/cards/types.rs
+++ b/crates/opsml_types/src/cards/types.rs
@@ -1,3 +1,4 @@
+use crate::contracts::ServiceType;
 use crate::error::TypeError;
 use crate::types::RegistryType;
 use pyo3::prelude::*;
@@ -66,6 +67,14 @@ impl CardTable {
             RegistryType::Artifact => CardTable::Artifact,
             RegistryType::Evaluation => CardTable::Evaluation,
             RegistryType::Mcp => CardTable::Mcp,
+        }
+    }
+
+    pub fn from_service_type(service_type: &ServiceType) -> Self {
+        match service_type {
+            ServiceType::Mcp => CardTable::Mcp,
+            ServiceType::Api => CardTable::Service,
+            _ => CardTable::Service,
         }
     }
 }

--- a/crates/opsml_types/src/cards/types.rs
+++ b/crates/opsml_types/src/cards/types.rs
@@ -23,6 +23,7 @@ pub enum CardTable {
     Service,
     Artifact,
     Evaluation,
+    Mcp,
 }
 
 impl fmt::Display for CardTable {
@@ -40,6 +41,7 @@ impl fmt::Display for CardTable {
             CardTable::AuditEvent => "opsml_audit_event",
             CardTable::Prompt => "opsml_prompt_registry",
             CardTable::Service => "opsml_service_registry",
+            CardTable::Mcp => "opsml_mcp_registry",
             CardTable::Artifact => "opsml_artifact_registry",
             CardTable::Evaluation => "opsml_evaluation_registry",
         };
@@ -63,6 +65,7 @@ impl CardTable {
             RegistryType::Service => CardTable::Service,
             RegistryType::Artifact => CardTable::Artifact,
             RegistryType::Evaluation => CardTable::Evaluation,
+            RegistryType::Mcp => CardTable::Mcp,
         }
     }
 }

--- a/crates/opsml_types/src/contracts/card.rs
+++ b/crates/opsml_types/src/contracts/card.rs
@@ -281,7 +281,6 @@ pub struct CardQueryArgs {
     pub tags: Option<Vec<String>>,
     pub limit: Option<i32>,
     pub sort_by_timestamp: Option<bool>,
-    pub service_type: Option<String>,
     pub registry_type: RegistryType,
 }
 

--- a/crates/opsml_types/src/contracts/card.rs
+++ b/crates/opsml_types/src/contracts/card.rs
@@ -247,7 +247,7 @@ pub struct ServiceQueryArgs {
     pub space: Option<String>,
     pub name: Option<String>,
     pub tags: Option<Vec<String>>,
-    pub service_type: Option<String>,
+    pub service_type: ServiceType,
 }
 
 impl ServiceQueryArgs {

--- a/crates/opsml_types/src/contracts/service.rs
+++ b/crates/opsml_types/src/contracts/service.rs
@@ -6,9 +6,10 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt::Display;
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash, Default)]
 #[pyclass]
 pub enum ServiceType {
+    #[default]
     #[serde(alias = "API", alias = "api")]
     Api,
     #[serde(alias = "MCP", alias = "mcp")]

--- a/crates/opsml_types/src/types.rs
+++ b/crates/opsml_types/src/types.rs
@@ -23,6 +23,7 @@ pub enum RegistryType {
     ArtifactKey,
     Prompt,
     Service,
+    Mcp,
     Artifact,
     Evaluation,
 }
@@ -47,6 +48,7 @@ impl<'de> Deserialize<'de> for RegistryType {
             "service" => Ok(RegistryType::Service),
             "artifact" => Ok(RegistryType::Artifact),
             "evaluation" => Ok(RegistryType::Evaluation),
+            "mcp" => Ok(RegistryType::Mcp),
             _ => Err(serde::de::Error::custom(format!(
                 "Invalid registry type: {s}"
             ))),
@@ -70,6 +72,7 @@ impl Display for RegistryType {
             RegistryType::Service => write!(f, "service"),
             RegistryType::Artifact => write!(f, "artifact"),
             RegistryType::Evaluation => write!(f, "evaluation"),
+            RegistryType::Mcp => write!(f, "mcp"),
         }
     }
 }
@@ -89,6 +92,7 @@ impl RegistryType {
             "service" => Ok(RegistryType::Service),
             "artifact" => Ok(RegistryType::Artifact),
             "evaluation" => Ok(RegistryType::Evaluation),
+            "mcp" => Ok(RegistryType::Mcp),
             _ => Err(TypeError::InvalidRegistryType),
         }
     }
@@ -108,6 +112,7 @@ impl RegistryType {
             RegistryType::Service => b"service",
             RegistryType::Artifact => b"artifact",
             RegistryType::Evaluation => b"evaluation",
+            RegistryType::Mcp => b"mcp",
         }
     }
 }


### PR DESCRIPTION
## Pull Request

### Short Summary
When starting on UI work, I quickly realized it's better to keep `mcp` and eventually `agents` as their own separate registries even though they all current roll up into `ServiceCards`. 

