### PR TITLE
add flaky macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4331,6 +4331,7 @@ dependencies = [
  "serde_qs 0.15.0",
  "sqlx",
  "tempfile",
+ "test_utils",
  "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
@@ -7166,6 +7167,13 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "test_utils"
+version = "0.1.0"
+dependencies = [
+ "tokio",
+]
 
 [[package]]
 name = "testing_table"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ opsml-toml = { path = "crates/opsml_toml" }
 opsml-types = { path = "crates/opsml_types" }
 opsml-utils = { path = "crates/opsml_utils" }
 opsml-version = { path = "crates/opsml_version" }
+test_utils = { path = "crates/test_utils" }
 
 aes-gcm = "0.*"
 anyhow = "1.0.93"

--- a/crates/opsml_server/Cargo.toml
+++ b/crates/opsml_server/Cargo.toml
@@ -56,6 +56,7 @@ mockito = { workspace = true }
 rand = "0.*"
 tower = { version = "0.*", features = ["util"] }
 jsonwebtoken = { workspace = true }
+test_utils = { workspace = true }
 
 [[test]]
 name = "integration"

--- a/crates/opsml_server/tests/api/files.rs
+++ b/crates/opsml_server/tests/api/files.rs
@@ -4,97 +4,99 @@ use axum::{
     http::{header, Request, StatusCode},
 };
 use http_body_util::BodyExt; // for `collect`
-
 use opsml_types::{contracts::*, RegistryType};
+use test_utils::retry_flaky_test;
 
 #[tokio::test]
 async fn test_opsml_server_render_file() {
-    let mut helper = TestHelper::new(None).await;
+    retry_flaky_test!({
+        let mut helper = TestHelper::new(None).await;
 
-    helper.create_modelcard().await;
-    let path = helper.create_files();
+        helper.create_modelcard().await;
+        let path = helper.create_files();
 
-    let list_query = ListFileQuery { path: path.clone() };
+        let list_query = ListFileQuery { path: path.clone() };
 
-    let query_string = serde_qs::to_string(&list_query).unwrap();
+        let query_string = serde_qs::to_string(&list_query).unwrap();
 
-    // check if a card UID exists (get request with UidRequest params)
-    let request = Request::builder()
-        .uri(format!("/opsml/api/files/tree?{query_string}"))
-        .method("GET")
-        .body(Body::empty())
-        .unwrap();
+        // check if a card UID exists (get request with UidRequest params)
+        let request = Request::builder()
+            .uri(format!("/opsml/api/files/tree?{query_string}"))
+            .method("GET")
+            .body(Body::empty())
+            .unwrap();
 
-    let response = helper.send_oneshot(request).await;
-    assert_eq!(response.status(), StatusCode::OK);
+        let response = helper.send_oneshot(request).await;
+        assert_eq!(response.status(), StatusCode::OK);
 
-    // get response text
-    let body_bytes = response.into_body().collect().await.unwrap().to_bytes();
-    let file_tree: FileTreeResponse = serde_json::from_slice(&body_bytes).unwrap();
+        // get response text
+        let body_bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let file_tree: FileTreeResponse = serde_json::from_slice(&body_bytes).unwrap();
 
-    assert!(file_tree.files.len() == 2);
+        assert!(file_tree.files.len() == 2);
 
-    let file1req = RawFileRequest {
-        path: file_tree.files[0].path.clone(),
-        uid: helper.key.uid.clone(),
-        registry_type: RegistryType::Model,
-    };
+        let file1req = RawFileRequest {
+            path: file_tree.files[0].path.clone(),
+            uid: helper.key.uid.clone(),
+            registry_type: RegistryType::Model,
+        };
 
-    let request = Request::builder()
-        .uri("/opsml/api/files/content")
-        .method("POST")
-        .header(header::CONTENT_TYPE, "application/json")
-        .body(Body::from(serde_json::to_string(&file1req).unwrap()))
-        .unwrap();
+        let request = Request::builder()
+            .uri("/opsml/api/files/content")
+            .method("POST")
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&file1req).unwrap()))
+            .unwrap();
 
-    let response = helper.send_oneshot(request).await;
-    assert_eq!(response.status(), StatusCode::OK);
+        let response = helper.send_oneshot(request).await;
+        assert_eq!(response.status(), StatusCode::OK);
 
-    let body_bytes = response.into_body().collect().await.unwrap().to_bytes();
-    let file1: RawFile = serde_json::from_slice(&body_bytes).unwrap();
-    assert!(file1.mime_type == "application/json");
+        let body_bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let file1: RawFile = serde_json::from_slice(&body_bytes).unwrap();
+        assert!(file1.mime_type == "application/json");
 
-    let file2req = RawFileRequest {
-        path: file_tree.files[1].path.clone(),
-        uid: helper.key.uid.clone(),
-        registry_type: RegistryType::Model,
-    };
+        let file2req = RawFileRequest {
+            path: file_tree.files[1].path.clone(),
+            uid: helper.key.uid.clone(),
+            registry_type: RegistryType::Model,
+        };
 
-    let request = Request::builder()
-        .uri("/opsml/api/files/content")
-        .method("POST")
-        .header(header::CONTENT_TYPE, "application/json")
-        .body(Body::from(serde_json::to_string(&file2req).unwrap()))
-        .unwrap();
+        let request = Request::builder()
+            .uri("/opsml/api/files/content")
+            .method("POST")
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&file2req).unwrap()))
+            .unwrap();
 
-    let response = helper.send_oneshot(request).await;
-    assert_eq!(response.status(), StatusCode::OK);
+        let response = helper.send_oneshot(request).await;
+        assert_eq!(response.status(), StatusCode::OK);
 
-    let body_bytes = response.into_body().collect().await.unwrap().to_bytes();
-    let file2: RawFile = serde_json::from_slice(&body_bytes).unwrap();
-    assert!(file2.mime_type == "image/png");
+        let body_bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let file2: RawFile = serde_json::from_slice(&body_bytes).unwrap();
+        assert!(file2.mime_type == "image/png");
 
-    // add test for batch file content retrieval
-    let files_req = RawFileRequest {
-        path: path.clone(),
-        uid: helper.key.uid.clone(),
-        registry_type: RegistryType::Model,
-    };
+        // add test for batch file content retrieval
+        let files_req = RawFileRequest {
+            path: path.clone(),
+            uid: helper.key.uid.clone(),
+            registry_type: RegistryType::Model,
+        };
 
-    let request = Request::builder()
-        .uri("/opsml/api/files/content/batch")
-        .method("POST")
-        .header(header::CONTENT_TYPE, "application/json")
-        .body(Body::from(serde_json::to_string(&files_req).unwrap()))
-        .unwrap();
+        let request = Request::builder()
+            .uri("/opsml/api/files/content/batch")
+            .method("POST")
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&files_req).unwrap()))
+            .unwrap();
 
-    let response = helper.send_oneshot(request).await;
-    assert_eq!(response.status(), StatusCode::OK);
+        let response = helper.send_oneshot(request).await;
+        assert_eq!(response.status(), StatusCode::OK);
 
-    let body_bytes = response.into_body().collect().await.unwrap().to_bytes();
-    let files: Vec<RawFile> = serde_json::from_slice(&body_bytes).unwrap();
+        let body_bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let files: Vec<RawFile> = serde_json::from_slice(&body_bytes).unwrap();
 
-    assert!(files.len() == 2);
+        assert!(files.len() == 2);
+    });
 }
 
 #[tokio::test]

--- a/crates/test_utils/Cargo.toml
+++ b/crates/test_utils/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "test_utils"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tokio = { workspace = true }

--- a/crates/test_utils/src/lib.rs
+++ b/crates/test_utils/src/lib.rs
@@ -1,0 +1,59 @@
+#[macro_export]
+macro_rules! retry_flaky_test {
+    ($attempts:expr, $delay_ms:expr, $test_logic:block) => {{
+        use std::panic::UnwindSafe;
+        use tokio::task::JoinHandle;
+        use tokio::time::{self, Duration};
+
+        const MAX_ATTEMPTS: usize = $attempts;
+        const RETRY_DELAY: Duration = Duration::from_millis($delay_ms);
+
+        let test_fn = || async move { $test_logic };
+
+        for attempt in 1..=MAX_ATTEMPTS {
+            let handle: JoinHandle<()> = tokio::task::spawn(test_fn());
+            let result = handle.await;
+
+            match result {
+                Ok(_) => {
+                    return;
+                }
+
+                Err(e) if e.is_panic() => {
+                    if attempt < MAX_ATTEMPTS {
+                        eprintln!(
+                            "Flaky test attempt {} failed (Task Panic). Retrying in {:?}...",
+                            attempt, RETRY_DELAY
+                        );
+                        time::sleep(RETRY_DELAY).await;
+                    } else {
+                        eprintln!(
+                            "Flaky test failed on final attempt {}. Max retries reached.",
+                            attempt
+                        );
+                        if let Ok(panic_payload) = e.try_into_panic() {
+                            std::panic::resume_unwind(panic_payload);
+                        } else {
+                            panic!("Task panicked but could not recover payload on final retry.");
+                        }
+                    }
+                }
+                Err(e) => {
+                    eprintln!(
+                        "Test failed with unexpected JoinError (not a panic): {:?}",
+                        e
+                    );
+                    panic!(
+                        "Task failed due to cancellation or unexpected error: {:?}",
+                        e
+                    );
+                }
+            }
+        }
+    }};
+
+    // Default invocation
+    ($test_logic:block) => {
+        retry_flaky_test!(3, 1000, $test_logic)
+    };
+}


### PR DESCRIPTION
## Pull Request

### Short Summary
Introducing a declarative macro that can be used for flaky tests

- Opsml contains various integration tests that are often flaky based on timing or env issues when running multiple tests. To remedy this flakyness, we need a way to retry flaky tests. One way we can do this, and is introduced in this pr, is the use of a declarative macro where we can specify the number of retries in addition to the time delay between retries. Currently, it is applied to both `test_opsml_server_card_get_card()` and `test_opsml_server_render_file()` in the `opsml_server` test suite
