### PR TITLE
fix ort and gh issues

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -8,6 +8,9 @@ on:
   release:
     types: [published]
 
+env:
+  PYTHON_VERSION: "3.12"
+
 permissions:
   contents: write
   pages: write
@@ -30,19 +33,22 @@ jobs:
           docker-images: true
           swap-storage: true
 
-      - name: Set up uv
-        run: curl -LsSf https://astral.sh/uv/install.sh | sh
-
-      - name: set up python
-        uses: actions/setup-python@v5
+      - name: Install uv and set the python version
+        uses: astral-sh/setup-uv@v6
         with:
-          python-version: "3.11"
+          python-version: ${{ env.PYTHON_VERSION }}
+          ignore-nothing-to-cache: true
 
       - name: Install Protocol Buffers Compiler
         uses: arduino/setup-protoc@v3
         with:
           version: "33.2"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcurl4-openssl-dev pkg-config
 
       - name: Build Docs
         working-directory: ./py-opsml

--- a/.github/workflows/release-client.yml
+++ b/.github/workflows/release-client.yml
@@ -27,6 +27,7 @@ jobs:
         uses: astral-sh/setup-uv@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+          ignore-nothing-to-cache: true
 
       - name: Install Protocol Buffers Compiler
         uses: arduino/setup-protoc@v3
@@ -37,7 +38,7 @@ jobs:
       - name: Install dependencies, build stubs, update package name, and build sdist
         working-directory: ./py-opsml
         run: |
-          pip install -U twine tomli tomli-w
+          pip install "twine>=6.1.0" tomli tomli-w
           python ./scripts/update_package_name.py ./pyproject.toml "opsml-client"
           python ./scripts/assemble_stubs.py
 
@@ -86,11 +87,12 @@ jobs:
         uses: astral-sh/setup-uv@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+          ignore-nothing-to-cache: true
 
       - name: Update package name to opsml-client
         working-directory: ./py-opsml
         run: |
-          pip install -U twine tomli tomli-w
+          pip install "twine>=6.1.0" tomli tomli-w
           python ./scripts/update_package_name.py ./pyproject.toml "opsml-client"
           python ./scripts/assemble_stubs.py
 
@@ -220,6 +222,7 @@ jobs:
         uses: astral-sh/setup-uv@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+          ignore-nothing-to-cache: true
 
       - name: Install Protocol Buffers Compiler
         uses: arduino/setup-protoc@v3
@@ -230,7 +233,7 @@ jobs:
       - name: Update package name to opsml-client
         working-directory: ./py-opsml
         run: |
-          pip install -U twine tomli tomli-w
+          pip install "twine>=6.1.0" tomli tomli-w
           python ./scripts/update_package_name.py ./pyproject.toml "opsml-client"
           python ./scripts/assemble_stubs.py
 
@@ -278,6 +281,7 @@ jobs:
         uses: astral-sh/setup-uv@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+          ignore-nothing-to-cache: true
 
       - name: Install Protocol Buffers Compiler
         uses: arduino/setup-protoc@v3
@@ -288,7 +292,7 @@ jobs:
       - name: Update package name to opsml-client
         working-directory: ./py-opsml
         run: |
-          pip install -U twine tomli tomli-w
+          pip install "twine>=6.1.0" tomli tomli-w
           python ./scripts/update_package_name.py ./pyproject.toml "opsml-client"
           python ./scripts/assemble_stubs.py
 
@@ -392,7 +396,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: pip install -U twine
+      - run: pip install "twine>=6.1.0"
       - name: get dist artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -27,11 +27,12 @@ jobs:
         uses: astral-sh/setup-uv@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+          ignore-nothing-to-cache: true
 
       - name: Install dependencies, build stubs, update package name, and build sdist
         working-directory: ./py-opsml
         run: |
-          pip install -U twine tomli tomli-w
+          pip install "twine>=6.1.0" tomli tomli-w
           python ./scripts/assemble_stubs.py
 
       - name: Install build dependencies
@@ -80,8 +81,9 @@ jobs:
         uses: astral-sh/setup-uv@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+          ignore-nothing-to-cache: true
 
-      - run: pip install -U twine
+      - run: pip install "twine>=6.1.0"
 
       - name: Set OPENSSL_DIR environment variable
         run: echo "OPENSSL_DIR=/usr" >> $GITHUB_ENV
@@ -214,6 +216,7 @@ jobs:
         uses: astral-sh/setup-uv@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+          ignore-nothing-to-cache: true
 
       - name: Install Protocol Buffers Compiler
         uses: arduino/setup-protoc@v3
@@ -221,7 +224,7 @@ jobs:
           version: "33.2"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - run: pip install -U twine
+      - run: pip install "twine>=6.1.0"
 
       - name: Build stubs
         working-directory: ./py-opsml
@@ -272,6 +275,7 @@ jobs:
         uses: astral-sh/setup-uv@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+          ignore-nothing-to-cache: true
 
       - name: Install Protocol Buffers Compiler
         uses: arduino/setup-protoc@v3
@@ -279,7 +283,7 @@ jobs:
           version: "33.2"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - run: pip install -U twine
+      - run: pip install "twine>=6.1.0"
 
       - name: Build stubs
         working-directory: ./py-opsml
@@ -386,7 +390,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: pip install -U twine
+      - run: pip install "twine>=6.1.0"
       - name: get dist artifacts
         uses: actions/download-artifact@v4
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,9 +547,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a7b350e3bb1767102698302bc37256cbd48422809984b98d292c40e2579aa9"
+checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -558,9 +558,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.37.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b092fe214090261288111db7a2b2c2118e5a7f30dc2569f1732c4069a6840549"
+checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
 dependencies = [
  "cc",
  "cmake",
@@ -734,9 +734,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.13"
+version = "1.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc50d0f63e714784b84223abd7abbc8577de8c35d699e0edd19f0a88a08ae13"
+checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -745,9 +745,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.64.5"
+version = "0.64.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180dddf5ef0f52a2f99e2fada10e16ea610e507ef6148a42bdc4d5867596aa00"
+checksum = "6750f3dd509b0694a4377f0293ed2f9630d710b1cebe281fa8bac8f099f88bc6"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -766,9 +766,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.19"
+version = "0.60.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c0b3e587fbaa5d7f7e870544508af8ce82ea47cd30376e69e1e37c4ac746f79"
+checksum = "faf09d74e5e32f76b8762da505a3cd59303e367a664ca67295387baa8c1d7548"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -777,9 +777,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.63.5"
+version = "0.63.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d619373d490ad70966994801bc126846afaa0d1ee920697a031f0cf63f2568e7"
+checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
@@ -799,9 +799,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.1.11"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00ccbb08c10f6bcf912f398188e42ee2eab5f1767ce215a02a73bc5df1bbdd95"
+checksum = "6a2f165a7feee6f263028b899d0a181987f4fa7179a6411a32a439fba7c5f769"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -829,27 +829,27 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.62.4"
+version = "0.62.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b3a779093e18cad88bbae08dc4261e1d95018c4c5b9356a52bcae7c0b6e9bb"
+checksum = "9648b0bb82a2eedd844052c6ad2a1a822d1f8e3adee5fbf668366717e428856a"
 dependencies = [
  "aws-smithy-types",
 ]
 
 [[package]]
 name = "aws-smithy-observability"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d3f39d5bb871aaf461d59144557f16d5927a5248a983a40654d9cf3b9ba183b"
+checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
 dependencies = [
  "aws-smithy-runtime-api",
 ]
 
 [[package]]
 name = "aws-smithy-query"
-version = "0.60.14"
+version = "0.60.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f76a580e3d8f8961e5d48763214025a2af65c2fa4cd1fb7f270a0e107a71b0"
+checksum = "1a56d79744fb3edb5d722ef79d86081e121d3b9422cb209eb03aea6aa4f21ebd"
 dependencies = [
  "aws-smithy-types",
  "urlencoding",
@@ -857,9 +857,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.10.2"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ccf7f6eba8b2dcf8ce9b74806c6c185659c311665c4bf8d6e71ebd454db6bf"
+checksum = "028999056d2d2fd58a697232f9eec4a643cf73a71cf327690a7edad1d2af2110"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -882,9 +882,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.11.5"
+version = "1.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4af6e5def28be846479bbeac55aa4603d6f7986fc5da4601ba324dd5d377516"
+checksum = "876ab3c9c29791ba4ba02b780a3049e21ec63dabda09268b175272c3733a79e6"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -899,9 +899,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.4.5"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca2734c16913a45343b37313605d84e7d8b34a4611598ce1d25b35860a2bed3"
+checksum = "d2b1117b3b2bbe166d11199b540ceed0d0f7676e36e7b962b5a437a9971eac75"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -925,9 +925,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.60.14"
+version = "0.60.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b53543b4b86ed43f051644f704a98c7291b3618b67adf057ee77a366fa52fcaa"
+checksum = "0ce02add1aa3677d022f8adf81dcbe3046a95f17a1b1e8979c145cd21d3d22b3"
 dependencies = [
  "xmlparser",
 ]
@@ -1550,9 +1550,9 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.18.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af9a108e542ddf1de36743a6126e94d6659dccda38fc8a77e80b915102ac784a"
+checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -3132,9 +3132,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
@@ -7425,9 +7425,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.38.2"
+version = "0.38.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efc19935b4b66baa6f654ac7924c192f55b175c00a7ab72410fc24284dacda8"
+checksum = "d03c61d2a49c649a15c407338afe7accafde9dac869995dccb73e5f7ef7d9034"
 dependencies = [
  "libc",
  "memchr",
@@ -7689,9 +7689,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9247,9 +9247,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c745c48e1007337ed136dc99df34128b9faa6ed542d80a1c673cf55a6d7236c8"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ mimalloc = { version = "*", features = ["secure"] }
 mockall = "0.*"
 mockito = "1.*"
 names = "0.*"
-ort = { version = "2.0.0-rc.10" }
+ort = { version = ">=2.0.0-rc.11" }
 owo-colors = "4.*"
 password-auth = "1.*"
 pbkdf2 = "0.*"

--- a/crates/opsml_interfaces/Cargo.toml
+++ b/crates/opsml_interfaces/Cargo.toml
@@ -11,7 +11,6 @@ doctest = false
 opsml-types = { workspace = true }
 opsml-state = { workspace = true }
 opsml-utils = { workspace = true }
-ort = { workspace = true }
 potato-head = { workspace = true }
 pyo3 = { workspace = true }
 pythonize = { workspace = true }
@@ -24,3 +23,6 @@ tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+
+[target.'cfg(not(all(target_arch = "x86_64", target_os = "macos")))'.dependencies]
+ort = { workspace = true }

--- a/crates/opsml_interfaces/src/error.rs
+++ b/crates/opsml_interfaces/src/error.rs
@@ -197,9 +197,11 @@ pub enum OnnxError {
     #[error("{0}")]
     Error(String),
 
+    #[cfg(not(all(target_arch = "x86_64", target_os = "macos")))]
     #[error("Failed to create onnx session: {0}")]
     SessionCreateError(ort::Error),
 
+    #[cfg(not(all(target_arch = "x86_64", target_os = "macos")))]
     #[error("Failed to commit onnx session: {0}")]
     SessionCommitError(ort::Error),
 

--- a/crates/opsml_interfaces/src/model/onnx/types.rs
+++ b/crates/opsml_interfaces/src/model/onnx/types.rs
@@ -4,7 +4,9 @@ use std::vec;
 use crate::error::OnnxError;
 use crate::{Feature, FeatureSchema, OnnxSchema};
 use opsml_utils::PyHelperFuncs;
+#[cfg(not(all(target_arch = "x86_64", target_os = "macos")))]
 use ort::session::Session;
+#[cfg(not(all(target_arch = "x86_64", target_os = "macos")))]
 use ort::value::ValueType;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
@@ -19,7 +21,7 @@ use std::fmt;
 use std::path::Path;
 use tracing::{debug, instrument};
 
-/// Extracts input and output schema from the ort ONNX session.
+#[cfg(not(all(target_arch = "x86_64", target_os = "macos")))]
 fn parse_session_schema(
     ort_session: &Session,
 ) -> Result<(FeatureSchema, FeatureSchema), OnnxError> {
@@ -98,13 +100,17 @@ impl OnnxSession {
             .extract::<Vec<u8>>()
             .map_err(OnnxError::PyModelBytesExtractError)?;
 
-        // extract onnx_bytes
-        let session = Session::builder()
-            .map_err(OnnxError::SessionCreateError)?
-            .commit_from_memory(&model_bytes)
-            .map_err(OnnxError::SessionCommitError)?;
+        #[cfg(not(all(target_arch = "x86_64", target_os = "macos")))]
+        let (input_schema, output_schema) = {
+            let session = Session::builder()
+                .map_err(OnnxError::SessionCreateError)?
+                .commit_from_memory(&model_bytes)
+                .map_err(OnnxError::SessionCommitError)?;
+            parse_session_schema(&session)?
+        };
 
-        let (input_schema, output_schema) = parse_session_schema(&session)?;
+        #[cfg(all(target_arch = "x86_64", target_os = "macos"))]
+        let (input_schema, output_schema) = (FeatureSchema::default(), FeatureSchema::default());
 
         let schema = OnnxSchema {
             input_features: input_schema,
@@ -289,12 +295,17 @@ impl OnnxSession {
             .getattr("__version__")?
             .extract::<String>()?;
 
-        let session = Session::builder()
-            .map_err(OnnxError::SessionCreateError)?
-            .commit_from_file(filepath)
-            .map_err(OnnxError::SessionCommitError)?;
+        #[cfg(not(all(target_arch = "x86_64", target_os = "macos")))]
+        let (input_schema, output_schema) = {
+            let session = Session::builder()
+                .map_err(OnnxError::SessionCreateError)?
+                .commit_from_file(filepath)
+                .map_err(OnnxError::SessionCommitError)?;
+            parse_session_schema(&session)?
+        };
 
-        let (input_schema, output_schema) = parse_session_schema(&session)?;
+        #[cfg(all(target_arch = "x86_64", target_os = "macos"))]
+        let (input_schema, output_schema) = (FeatureSchema::default(), FeatureSchema::default());
 
         let schema = OnnxSchema {
             input_features: input_schema,


### PR DESCRIPTION
## Pull Request

### Fix: ONNX x86_64 macOS build compatibility + CI wheel validation
                                                                                                                       
  Summary         

  - Fix twine --strict CI failures caused by PEP 639 wheel metadata fields (License-Expression, License-File) being
  rejected by older twine versions
  - Exclude ort (ONNX Runtime) from opsml_interfaces on x86_64 macOS to fix build failures on that target
  - Standardize setup-uv usage across CI workflows

  Changes

  CI / Workflows
  - Pin twine>=6.1.0 in release-client.yml, release-server.yml, and publish-docs.yml
  - Add ignore-nothing-to-cache: true to all astral-sh/setup-uv@v6 steps for consistency
  - Migrate publish-docs.yml from setup-python + manual uv install to astral-sh/setup-uv@v6; add missing
  libcurl4-openssl-dev/pkg-config build deps

  ONNX / Rust (opsml_interfaces)
  - Bump ort workspace dependency to >=2.0.0-rc.11
  - Gate ort dependency and all ort-dependent code behind #[cfg(not(all(target_arch = "x86_64", target_os = "macos")))]
   — ort does not build on x86_64 macOS (Intel), so session schema parsing returns empty FeatureSchema on that platform
   instead of failing to compile
  - Affected: Cargo.toml target-specific dep, error.rs error variants, types.rs imports and both OnnxSession
  constructors

