### PR TITLE
Feat 357 hooks

### DIFF
--- a/crates/opsml_cards/src/lib.rs
+++ b/crates/opsml_cards/src/lib.rs
@@ -23,6 +23,6 @@ pub use subagent::{
 pub use tool::{ToolCard, ToolError, parse_tool_markdown};
 pub use tool::installer::{
     ClaudeCodeInstaller, CodexInstaller, CopilotInstaller, GeminiCliInstaller,
-    McpConfigInstaller, SlashCommandInstaller,
+    HookInstaller, McpConfigInstaller, SlashCommandInstaller,
 };
 pub use utils::*;

--- a/crates/opsml_cards/src/lib.rs
+++ b/crates/opsml_cards/src/lib.rs
@@ -20,9 +20,8 @@ pub use subagent::{
     ClaudeCodeTarget, CodexTarget, CopilotTarget, GeminiCliTarget, SubAgentCard, SubAgentCliTarget,
     SubAgentError, parse_subagent_markdown,
 };
-pub use tool::{ToolCard, ToolError, parse_tool_markdown};
-pub use tool::installer::{
-    ClaudeCodeInstaller, CodexInstaller, CopilotInstaller, GeminiCliInstaller,
-    HookInstaller, McpConfigInstaller, SlashCommandInstaller,
+pub use tool::{
+    ClaudeCodeInstaller, CodexInstaller, CopilotInstaller, GeminiCliInstaller, HookInstaller,
+    McpConfigInstaller, SlashCommandInstaller, ToolCard, ToolError, parse_tool_markdown,
 };
 pub use utils::*;

--- a/crates/opsml_cards/src/tool/card.rs
+++ b/crates/opsml_cards/src/tool/card.rs
@@ -296,7 +296,10 @@ impl ToolCard {
                     perms.set_mode(0o700);
                     std::fs::set_permissions(&path, perms)?;
                 }
-                let relative_path = PathBuf::from(format!(".opsml/hooks/{}.sh", self.name));
+                let relative_path = std::env::current_dir()
+                    .ok()
+                    .and_then(|cwd| path.strip_prefix(&cwd).ok().map(|p| p.to_path_buf()))
+                    .unwrap_or_else(|| path.clone());
                 if let Some(installer) = hook_installer {
                     installer.install_hook(
                         &self.name,
@@ -844,6 +847,48 @@ mod tests {
                 "Claude Code command path"
             );
         });
+    }
+
+    #[test]
+    fn test_pull_hook_custom_output_dir_config_path_correct() {
+        use crate::tool::installer::ClaudeCodeInstaller;
+        let cwd_tmp = tempfile::tempdir().unwrap();
+        let install_tmp = tempfile::tempdir().unwrap();
+
+        let _guard = crate::tool::test_util::CWD_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let orig = std::env::current_dir().unwrap();
+        std::env::set_current_dir(cwd_tmp.path()).unwrap();
+
+        let card = make_hook_card("my-hook");
+        let installer = ClaudeCodeInstaller;
+        let path = card
+            .pull_artifacts(install_tmp.path().to_path_buf(), Some(&installer), false)
+            .unwrap();
+        assert!(path.exists(), "script must be written at install_dir");
+
+        let settings: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(cwd_tmp.path().join(".claude/settings.json")).unwrap(),
+        )
+        .unwrap();
+        let arr = settings["hooks"]["PostToolUse"].as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+
+        let command = arr[0]["hooks"][0]["command"].as_str().unwrap();
+        let script_path = std::path::Path::new(command);
+        // The command must resolve to the actual script location from CWD
+        let resolved = if script_path.is_absolute() {
+            script_path.to_path_buf()
+        } else {
+            cwd_tmp.path().join(script_path)
+        };
+        assert!(
+            resolved.exists(),
+            "command path '{command}' must resolve to an existing file from CWD, but it doesn't"
+        );
+
+        std::env::set_current_dir(orig).unwrap();
     }
 
     #[test]

--- a/crates/opsml_cards/src/tool/card.rs
+++ b/crates/opsml_cards/src/tool/card.rs
@@ -48,6 +48,10 @@ pub fn parse_tool_markdown(content: &str) -> Result<ToolCard, ToolError> {
         )));
     }
 
+    if let Some(m) = &spec.hook_matcher {
+        super::installer::validate_hook_matcher(m)?;
+    }
+
     let body_opt = if body.is_empty() { None } else { Some(body) };
     let name = spec.name.clone();
 
@@ -125,8 +129,27 @@ impl ToolCard {
     }
 
     pub fn calculate_content_hash(&self) -> Result<Vec<u8>, ToolError> {
+        fn sort_json_keys(v: serde_json::Value) -> serde_json::Value {
+            match v {
+                serde_json::Value::Object(map) => {
+                    let sorted: serde_json::Map<String, serde_json::Value> = map
+                        .into_iter()
+                        .map(|(k, v)| (k, sort_json_keys(v)))
+                        .collect::<std::collections::BTreeMap<_, _>>()
+                        .into_iter()
+                        .collect();
+                    serde_json::Value::Object(sorted)
+                }
+                serde_json::Value::Array(arr) => {
+                    serde_json::Value::Array(arr.into_iter().map(sort_json_keys).collect())
+                }
+                other => other,
+            }
+        }
+
         let mut hasher = Sha256::new();
-        let canonical = serde_json::to_vec(&self.spec)?;
+        let spec_value = serde_json::to_value(&self.spec)?;
+        let canonical = serde_json::to_vec(&sort_json_keys(spec_value))?;
         hasher.update(&canonical);
         if let Some(body) = &self.body {
             hasher.update(body.as_bytes());
@@ -160,6 +183,11 @@ impl ToolCard {
             hook_matcher: Option<&'a serde_json::Value>,
         }
 
+        let sanitized_api_config = self
+            .spec
+            .api_config
+            .as_ref()
+            .map(|c| c.sanitize_for_response());
         let fm = ToolFrontmatter {
             name: &self.spec.name,
             description: &self.spec.description,
@@ -167,7 +195,7 @@ impl ToolCard {
             args_schema: self.spec.args_schema.as_ref(),
             output_schema: self.spec.output_schema.as_ref(),
             script_config: self.spec.script_config.as_ref(),
-            api_config: self.spec.api_config.as_ref(),
+            api_config: sanitized_api_config.as_ref(),
             mcp_server_name: self.spec.mcp_server_name.as_deref(),
             allowed_tools: &self.spec.allowed_tools,
             requires_approval: self.spec.requires_approval,
@@ -200,6 +228,15 @@ impl ToolCard {
             )));
         }
         std::fs::create_dir_all(&install_dir)?;
+        let install_dir = install_dir.canonicalize()?;
+        if matches!(self.spec.tool_type, ToolType::ShellScript | ToolType::Hook)
+            && self.body.is_none()
+        {
+            return Err(ToolError::Error(format!(
+                "{} tool '{}' has no body; cannot install",
+                self.spec.tool_type, self.name
+            )));
+        }
         let body_content = self.body.as_deref().unwrap_or("");
 
         match &self.spec.tool_type {
@@ -210,7 +247,7 @@ impl ToolCard {
                 {
                     use std::os::unix::fs::PermissionsExt;
                     let mut perms = std::fs::metadata(&path)?.permissions();
-                    perms.set_mode(0o755);
+                    perms.set_mode(0o700);
                     std::fs::set_permissions(&path, perms)?;
                 }
                 Ok(path)
@@ -256,11 +293,10 @@ impl ToolCard {
                 {
                     use std::os::unix::fs::PermissionsExt;
                     let mut perms = std::fs::metadata(&path)?.permissions();
-                    perms.set_mode(0o755);
+                    perms.set_mode(0o700);
                     std::fs::set_permissions(&path, perms)?;
                 }
-                let relative_path =
-                    PathBuf::from(format!(".opsml/hooks/{}.sh", self.name));
+                let relative_path = PathBuf::from(format!(".opsml/hooks/{}.sh", self.name));
                 if let Some(installer) = hook_installer {
                     installer.install_hook(
                         &self.name,
@@ -457,8 +493,7 @@ mod tests {
     #[test]
     fn test_tool_card_json_roundtrip() {
         let spec = make_shell_spec();
-        let card =
-            ToolCard::new_rs(spec, Some("test-space"), Some("my-tool"), None, None).unwrap();
+        let card = ToolCard::new_rs(spec, Some("test-space"), Some("my-tool"), None, None).unwrap();
 
         let json = serde_json::to_string(&card).unwrap();
         let restored = ToolCard::model_validate_json(json).unwrap();
@@ -471,8 +506,7 @@ mod tests {
     #[test]
     fn test_tool_card_get_registry_card() {
         let spec = make_shell_spec();
-        let card =
-            ToolCard::new_rs(spec, Some("test-space"), Some("my-tool"), None, None).unwrap();
+        let card = ToolCard::new_rs(spec, Some("test-space"), Some("my-tool"), None, None).unwrap();
 
         let record = card.get_registry_card().unwrap();
         match record {
@@ -591,8 +625,7 @@ mod tests {
     fn test_pull_artifacts_mcp_server() {
         let tmp = tempfile::tempdir().unwrap();
         let spec = make_mcp_spec();
-        let card =
-            ToolCard::new_rs(spec, Some("test-space"), Some("my-mcp"), None, None).unwrap();
+        let card = ToolCard::new_rs(spec, Some("test-space"), Some("my-mcp"), None, None).unwrap();
 
         let path = card
             .pull_artifacts(tmp.path().to_path_buf(), None, false)
@@ -605,8 +638,7 @@ mod tests {
     fn test_pull_artifacts_api_call() {
         let tmp = tempfile::tempdir().unwrap();
         let spec = make_api_spec();
-        let card =
-            ToolCard::new_rs(spec, Some("test-space"), Some("my-api"), None, None).unwrap();
+        let card = ToolCard::new_rs(spec, Some("test-space"), Some("my-api"), None, None).unwrap();
 
         let path = card
             .pull_artifacts(tmp.path().to_path_buf(), None, false)
@@ -629,7 +661,9 @@ mod tests {
             "args": ["-y", "my-mcp-server"]
         });
 
-        installer.merge_mcp_entry("my-server", entry.clone()).unwrap();
+        installer
+            .merge_mcp_entry("my-server", entry.clone())
+            .unwrap();
         installer.merge_mcp_entry("my-server", entry).unwrap();
 
         let content = std::fs::read_to_string(installer.mcp_config_path()).unwrap();
@@ -740,7 +774,7 @@ mod tests {
         {
             use std::os::unix::fs::PermissionsExt;
             let perms = std::fs::metadata(&path).unwrap().permissions();
-            assert_eq!(perms.mode() & 0o777, 0o755);
+            assert_eq!(perms.mode() & 0o777, 0o700);
         }
     }
 
@@ -753,7 +787,8 @@ mod tests {
             tool_type: ToolType::Hook,
             ..Default::default()
         };
-        let card = ToolCard::new_rs(spec, Some("s"), Some("no-installer"), None, None).unwrap();
+        let mut card = ToolCard::new_rs(spec, Some("s"), Some("no-installer"), None, None).unwrap();
+        card.body = Some("#!/bin/bash\necho no-installer\n".to_string());
         let path = card
             .pull_artifacts(tmp.path().to_path_buf(), None, false)
             .unwrap();
@@ -805,8 +840,7 @@ mod tests {
             let arr = settings["hooks"]["PostToolUse"].as_array().unwrap();
             assert_eq!(arr.len(), 1);
             assert_eq!(
-                arr[0]["hooks"][0]["command"],
-                ".opsml/hooks/my-hook.sh",
+                arr[0]["hooks"][0]["command"], ".opsml/hooks/my-hook.sh",
                 "Claude Code command path"
             );
         });
@@ -830,8 +864,7 @@ mod tests {
             let arr = settings["hooks"]["post_tool_use"].as_array().unwrap();
             assert_eq!(arr.len(), 1);
             assert_eq!(
-                arr[0]["script"],
-                ".opsml/hooks/my-hook.sh",
+                arr[0]["script"], ".opsml/hooks/my-hook.sh",
                 "Gemini script path"
             );
         });
@@ -928,9 +961,10 @@ mod tests {
             );
 
             // Codex config
-            let codex: serde_json::Value =
-                serde_yaml::from_str(&std::fs::read_to_string(tmp.join(".codex/config.yaml")).unwrap())
-                    .unwrap();
+            let codex: serde_json::Value = serde_yaml::from_str(
+                &std::fs::read_to_string(tmp.join(".codex/config.yaml")).unwrap(),
+            )
+            .unwrap();
             assert!(
                 !codex["hooks"].as_array().unwrap().is_empty(),
                 "Codex hooks registered"
@@ -950,9 +984,10 @@ mod tests {
             card.pull_artifacts(tmp.to_path_buf(), Some(&ClaudeCodeInstaller), false)
                 .unwrap();
 
-            let codex: serde_json::Value =
-                serde_yaml::from_str(&std::fs::read_to_string(tmp.join(".codex/config.yaml")).unwrap())
-                    .unwrap();
+            let codex: serde_json::Value = serde_yaml::from_str(
+                &std::fs::read_to_string(tmp.join(".codex/config.yaml")).unwrap(),
+            )
+            .unwrap();
             assert_eq!(codex["hooks"].as_array().unwrap().len(), 1);
 
             let claude: serde_json::Value = serde_json::from_str(
@@ -988,5 +1023,192 @@ mod tests {
             let arr = gemini["hooks"]["post_tool_use"].as_array().unwrap();
             assert_eq!(arr.len(), 1, "Gemini must have exactly one hook entry");
         });
+    }
+
+    #[test]
+    fn test_parse_markdown_hook() {
+        let md = "---\nname: my-hook\ndescription: A hook\ntoolType: Hook\nhookEvents:\n  - PostToolUse\nhookMatcher:\n  tool: Write\n---\n";
+        let card = parse_tool_markdown(md).unwrap();
+        assert_eq!(card.spec.tool_type, ToolType::Hook);
+        assert_eq!(card.spec.hook_events, vec![HookEvent::PostToolUse]);
+        assert_eq!(
+            card.spec.hook_matcher,
+            Some(serde_json::json!({"tool": "Write"}))
+        );
+    }
+
+    #[test]
+    fn test_parse_markdown_mcp_server() {
+        let md = "---\nname: my-mcp\ndescription: An MCP server\ntoolType: McpServer\n\
+                  mcpServerName: my-server\n---\n";
+        let card = parse_tool_markdown(md).unwrap();
+        assert_eq!(card.spec.tool_type, ToolType::McpServer);
+        assert_eq!(card.spec.mcp_server_name, Some("my-server".to_string()));
+    }
+
+    #[test]
+    fn test_parse_markdown_api_call() {
+        let md = "---\nname: my-api\ndescription: An API call\ntoolType: ApiCall\napiConfig:\n  url: https://example.com\n  method: GET\n---\n";
+        let card = parse_tool_markdown(md).unwrap();
+        assert_eq!(card.spec.tool_type, ToolType::ApiCall);
+        assert_eq!(
+            card.spec.api_config.as_ref().unwrap().url,
+            "https://example.com"
+        );
+    }
+
+    #[test]
+    fn test_to_markdown_roundtrip_hook() {
+        let spec = ToolSpec {
+            name: "rt-hook".to_string(),
+            description: "roundtrip hook".to_string(),
+            tool_type: ToolType::Hook,
+            hook_events: vec![HookEvent::PostToolUse],
+            hook_matcher: Some(serde_json::json!({"tool": "Write"})),
+            ..Default::default()
+        };
+        let mut card = ToolCard::new_rs(spec, Some("test"), Some("rt-hook"), None, None).unwrap();
+        card.body = Some("#!/bin/bash\necho hi\n".to_string());
+        let md = card.to_markdown().unwrap();
+        let parsed = parse_tool_markdown(&md).unwrap();
+        assert_eq!(parsed.spec.tool_type, ToolType::Hook);
+        assert_eq!(parsed.spec.hook_events, vec![HookEvent::PostToolUse]);
+        assert_eq!(parsed.spec.hook_matcher, card.spec.hook_matcher);
+    }
+
+    #[test]
+    fn test_to_markdown_roundtrip_mcp_server() {
+        let spec = ToolSpec {
+            name: "rt-mcp".to_string(),
+            description: "roundtrip mcp".to_string(),
+            tool_type: ToolType::McpServer,
+            mcp_server_name: Some("my-server".to_string()),
+            ..Default::default()
+        };
+        let card = ToolCard::new_rs(spec, Some("test"), Some("rt-mcp"), None, None).unwrap();
+        let md = card.to_markdown().unwrap();
+        let parsed = parse_tool_markdown(&md).unwrap();
+        assert_eq!(parsed.spec.tool_type, ToolType::McpServer);
+        assert_eq!(parsed.spec.mcp_server_name, Some("my-server".to_string()));
+    }
+
+    #[test]
+    fn test_to_markdown_roundtrip_api_call() {
+        let spec = ToolSpec {
+            name: "rt-api".to_string(),
+            description: "roundtrip api".to_string(),
+            tool_type: ToolType::ApiCall,
+            api_config: Some(ApiCallConfig {
+                url: "https://example.com".to_string(),
+                method: "POST".to_string(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let card = ToolCard::new_rs(spec, Some("test"), Some("rt-api"), None, None).unwrap();
+        let md = card.to_markdown().unwrap();
+        let parsed = parse_tool_markdown(&md).unwrap();
+        assert_eq!(parsed.spec.tool_type, ToolType::ApiCall);
+        assert_eq!(
+            parsed.spec.api_config.as_ref().unwrap().url,
+            "https://example.com"
+        );
+    }
+
+    #[test]
+    fn test_pull_artifacts_shell_script_no_body_returns_error() {
+        let spec = ToolSpec {
+            name: "no-body".to_string(),
+            description: "test".to_string(),
+            tool_type: ToolType::ShellScript,
+            ..Default::default()
+        };
+        let card = ToolCard::new_rs(spec, Some("test"), Some("no-body"), None, None).unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let result = card.pull_artifacts(tmp.path().to_path_buf(), None, false);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("no body"));
+    }
+
+    #[test]
+    fn test_pull_artifacts_hook_no_body_returns_error() {
+        let spec = ToolSpec {
+            name: "no-body-hook".to_string(),
+            description: "test".to_string(),
+            tool_type: ToolType::Hook,
+            hook_events: vec![HookEvent::PostToolUse],
+            ..Default::default()
+        };
+        let card = ToolCard::new_rs(spec, Some("test"), Some("no-body-hook"), None, None).unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let result = card.pull_artifacts(tmp.path().to_path_buf(), None, false);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("no body"));
+    }
+
+    #[test]
+    fn test_from_path_unsupported_extension() {
+        let tmp = tempfile::tempdir().unwrap();
+        let yaml_path = tmp.path().join("card.yaml");
+        std::fs::write(&yaml_path, "name: test\n").unwrap();
+        let result = ToolCard::from_path(yaml_path);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .to_lowercase()
+                .contains("unsupported")
+        );
+    }
+
+    #[test]
+    fn test_calculate_content_hash_stable_key_order() {
+        let spec1 = ToolSpec {
+            name: "hash-test".to_string(),
+            description: "test".to_string(),
+            tool_type: ToolType::ApiCall,
+            args_schema: Some(serde_json::json!({"b": 2, "a": 1})),
+            ..Default::default()
+        };
+        let spec2 = ToolSpec {
+            name: "hash-test".to_string(),
+            description: "test".to_string(),
+            tool_type: ToolType::ApiCall,
+            args_schema: Some(serde_json::json!({"a": 1, "b": 2})),
+            ..Default::default()
+        };
+        let card1 = ToolCard::new_rs(spec1, Some("test"), Some("hash-test"), None, None).unwrap();
+        let card2 = ToolCard::new_rs(spec2, Some("test"), Some("hash-test"), None, None).unwrap();
+        assert_eq!(
+            card1.calculate_content_hash().unwrap(),
+            card2.calculate_content_hash().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_hook_matcher_roundtrip_hash_stable() {
+        // Verify that hook_matcher survives a to_markdown → parse_tool_markdown roundtrip
+        // and that content_hash is stable across the roundtrip.
+        let spec = ToolSpec {
+            name: "stable-hook".to_string(),
+            description: "test".to_string(),
+            tool_type: ToolType::Hook,
+            hook_events: vec![HookEvent::PostToolUse],
+            hook_matcher: Some(serde_json::json!({"tool": "Write"})),
+            ..Default::default()
+        };
+        let mut card =
+            ToolCard::new_rs(spec, Some("test"), Some("stable-hook"), None, None).unwrap();
+        card.body = Some("#!/bin/bash\n".to_string());
+        let hash_before = card.calculate_content_hash().unwrap();
+        let md = card.to_markdown().unwrap();
+        let parsed = parse_tool_markdown(&md).unwrap();
+        let hash_after = parsed.calculate_content_hash().unwrap();
+        assert_eq!(
+            parsed.spec.hook_matcher,
+            Some(serde_json::json!({"tool": "Write"}))
+        );
+        assert_eq!(hash_before, hash_after);
     }
 }

--- a/crates/opsml_cards/src/tool/card.rs
+++ b/crates/opsml_cards/src/tool/card.rs
@@ -759,4 +759,234 @@ mod tests {
             .unwrap();
         assert!(path.exists());
     }
+
+    // --- Cross-installer hook tests ---
+
+    fn with_hook_tempdir<F: FnOnce(&std::path::Path)>(f: F) {
+        let tmp = tempfile::tempdir().unwrap();
+        let _guard = crate::tool::test_util::CWD_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let orig = std::env::current_dir().unwrap();
+        std::env::set_current_dir(tmp.path()).unwrap();
+        f(tmp.path());
+        std::env::set_current_dir(orig).unwrap();
+    }
+
+    fn make_hook_card(name: &str) -> ToolCard {
+        let spec = ToolSpec {
+            name: name.to_string(),
+            description: "test hook".to_string(),
+            tool_type: ToolType::Hook,
+            hook_events: vec![HookEvent::PostToolUse],
+            hook_matcher: Some(serde_json::json!({"tool": "Write"})),
+            ..Default::default()
+        };
+        let mut card = ToolCard::new_rs(spec, Some("s"), Some(name), None, None).unwrap();
+        card.body = Some(format!("#!/bin/bash\necho {name}\n"));
+        card
+    }
+
+    #[test]
+    fn test_pull_hook_with_claude_installer() {
+        use crate::tool::installer::ClaudeCodeInstaller;
+        with_hook_tempdir(|tmp| {
+            let card = make_hook_card("my-hook");
+            let installer = ClaudeCodeInstaller;
+            let path = card
+                .pull_artifacts(tmp.to_path_buf(), Some(&installer), false)
+                .unwrap();
+            assert!(path.exists(), "script must be written");
+
+            let settings: serde_json::Value = serde_json::from_str(
+                &std::fs::read_to_string(tmp.join(".claude/settings.json")).unwrap(),
+            )
+            .unwrap();
+            let arr = settings["hooks"]["PostToolUse"].as_array().unwrap();
+            assert_eq!(arr.len(), 1);
+            assert_eq!(
+                arr[0]["hooks"][0]["command"],
+                ".opsml/hooks/my-hook.sh",
+                "Claude Code command path"
+            );
+        });
+    }
+
+    #[test]
+    fn test_pull_hook_with_gemini_installer() {
+        use crate::tool::installer::GeminiCliInstaller;
+        with_hook_tempdir(|tmp| {
+            let card = make_hook_card("my-hook");
+            let installer = GeminiCliInstaller;
+            let path = card
+                .pull_artifacts(tmp.to_path_buf(), Some(&installer), false)
+                .unwrap();
+            assert!(path.exists(), "script must be written");
+
+            let settings: serde_json::Value = serde_json::from_str(
+                &std::fs::read_to_string(tmp.join(".gemini/settings.json")).unwrap(),
+            )
+            .unwrap();
+            let arr = settings["hooks"]["post_tool_use"].as_array().unwrap();
+            assert_eq!(arr.len(), 1);
+            assert_eq!(
+                arr[0]["script"],
+                ".opsml/hooks/my-hook.sh",
+                "Gemini script path"
+            );
+        });
+    }
+
+    #[test]
+    fn test_pull_hook_with_codex_installer() {
+        use crate::tool::installer::CodexInstaller;
+        with_hook_tempdir(|tmp| {
+            let card = make_hook_card("my-hook");
+            let installer = CodexInstaller;
+            let path = card
+                .pull_artifacts(tmp.to_path_buf(), Some(&installer), false)
+                .unwrap();
+            assert!(path.exists(), "script must be written");
+
+            let config_path = tmp.join(".codex/config.yaml");
+            assert!(config_path.exists());
+            let parsed: serde_json::Value =
+                serde_yaml::from_str(&std::fs::read_to_string(&config_path).unwrap()).unwrap();
+            let hooks = parsed["hooks"].as_array().unwrap();
+            assert_eq!(hooks.len(), 1);
+            assert_eq!(hooks[0]["event"], "post_tool_use");
+            assert_eq!(hooks[0]["script"], ".opsml/hooks/my-hook.sh");
+        });
+    }
+
+    #[test]
+    fn test_pull_hook_with_copilot_installer() {
+        use crate::tool::installer::CopilotInstaller;
+        with_hook_tempdir(|tmp| {
+            let card = make_hook_card("my-hook");
+            let installer = CopilotInstaller;
+            let path = card
+                .pull_artifacts(tmp.to_path_buf(), Some(&installer), false)
+                .unwrap();
+            // Copilot writes the script but no config file
+            assert!(path.exists(), "script must be written");
+            assert!(
+                !tmp.join(".claude/settings.json").exists(),
+                "no Claude config for Copilot"
+            );
+            assert!(
+                !tmp.join(".gemini/settings.json").exists(),
+                "no Gemini config for Copilot"
+            );
+            assert!(
+                !tmp.join(".codex/config.yaml").exists(),
+                "no Codex config for Copilot"
+            );
+        });
+    }
+
+    #[test]
+    fn test_pull_hook_to_all_installers() {
+        use crate::tool::installer::{
+            ClaudeCodeInstaller, CodexInstaller, CopilotInstaller, GeminiCliInstaller,
+        };
+        with_hook_tempdir(|tmp| {
+            let card = make_hook_card("multi-hook");
+
+            // Pull to all four targets in sequence (same working dir = same config dir)
+            card.pull_artifacts(tmp.to_path_buf(), Some(&ClaudeCodeInstaller), false)
+                .unwrap();
+            card.pull_artifacts(tmp.to_path_buf(), Some(&GeminiCliInstaller), false)
+                .unwrap();
+            card.pull_artifacts(tmp.to_path_buf(), Some(&CodexInstaller), false)
+                .unwrap();
+            card.pull_artifacts(tmp.to_path_buf(), Some(&CopilotInstaller), false)
+                .unwrap();
+
+            // Script written once (subsequent pulls overwrite same path — that's fine)
+            let script = tmp.join(".opsml/hooks/multi-hook.sh");
+            assert!(script.exists(), "script must exist after all pulls");
+
+            // Claude Code config
+            let claude: serde_json::Value = serde_json::from_str(
+                &std::fs::read_to_string(tmp.join(".claude/settings.json")).unwrap(),
+            )
+            .unwrap();
+            assert!(
+                claude["hooks"]["PostToolUse"].as_array().is_some(),
+                "Claude PostToolUse registered"
+            );
+
+            // Gemini config
+            let gemini: serde_json::Value = serde_json::from_str(
+                &std::fs::read_to_string(tmp.join(".gemini/settings.json")).unwrap(),
+            )
+            .unwrap();
+            assert!(
+                gemini["hooks"]["post_tool_use"].as_array().is_some(),
+                "Gemini post_tool_use registered"
+            );
+
+            // Codex config
+            let codex: serde_json::Value =
+                serde_yaml::from_str(&std::fs::read_to_string(tmp.join(".codex/config.yaml")).unwrap())
+                    .unwrap();
+            assert!(
+                !codex["hooks"].as_array().unwrap().is_empty(),
+                "Codex hooks registered"
+            );
+        });
+    }
+
+    #[test]
+    fn test_pull_hook_codex_then_claude() {
+        use crate::tool::installer::{ClaudeCodeInstaller, CodexInstaller};
+        with_hook_tempdir(|tmp| {
+            let card = make_hook_card("cross-hook");
+
+            // Register in Codex first, then Claude — both configs must be independent
+            card.pull_artifacts(tmp.to_path_buf(), Some(&CodexInstaller), false)
+                .unwrap();
+            card.pull_artifacts(tmp.to_path_buf(), Some(&ClaudeCodeInstaller), false)
+                .unwrap();
+
+            let codex: serde_json::Value =
+                serde_yaml::from_str(&std::fs::read_to_string(tmp.join(".codex/config.yaml")).unwrap())
+                    .unwrap();
+            assert_eq!(codex["hooks"].as_array().unwrap().len(), 1);
+
+            let claude: serde_json::Value = serde_json::from_str(
+                &std::fs::read_to_string(tmp.join(".claude/settings.json")).unwrap(),
+            )
+            .unwrap();
+            assert!(claude["hooks"]["PostToolUse"].as_array().is_some());
+        });
+    }
+
+    #[test]
+    fn test_pull_hook_claude_then_gemini() {
+        use crate::tool::installer::{ClaudeCodeInstaller, GeminiCliInstaller};
+        with_hook_tempdir(|tmp| {
+            let card = make_hook_card("cross-hook2");
+
+            card.pull_artifacts(tmp.to_path_buf(), Some(&ClaudeCodeInstaller), false)
+                .unwrap();
+            card.pull_artifacts(tmp.to_path_buf(), Some(&GeminiCliInstaller), false)
+                .unwrap();
+
+            let claude: serde_json::Value = serde_json::from_str(
+                &std::fs::read_to_string(tmp.join(".claude/settings.json")).unwrap(),
+            )
+            .unwrap();
+            let arr = claude["hooks"]["PostToolUse"].as_array().unwrap();
+            assert_eq!(arr.len(), 1, "Claude must have exactly one hook entry");
+
+            let gemini: serde_json::Value = serde_json::from_str(
+                &std::fs::read_to_string(tmp.join(".gemini/settings.json")).unwrap(),
+            )
+            .unwrap();
+            let arr = gemini["hooks"]["post_tool_use"].as_array().unwrap();
+            assert_eq!(arr.len(), 1, "Gemini must have exactly one hook entry");
+        });
+    }
 }

--- a/crates/opsml_cards/src/tool/card.rs
+++ b/crates/opsml_cards/src/tool/card.rs
@@ -154,6 +154,10 @@ impl ToolCard {
             #[serde(skip_serializing_if = "<[_]>::is_empty")]
             allowed_tools: &'a [String],
             requires_approval: bool,
+            #[serde(skip_serializing_if = "<[_]>::is_empty")]
+            hook_events: &'a [opsml_types::contracts::tool::HookEvent],
+            #[serde(skip_serializing_if = "Option::is_none")]
+            hook_matcher: Option<&'a serde_json::Value>,
         }
 
         let fm = ToolFrontmatter {
@@ -167,6 +171,8 @@ impl ToolCard {
             mcp_server_name: self.spec.mcp_server_name.as_deref(),
             allowed_tools: &self.spec.allowed_tools,
             requires_approval: self.spec.requires_approval,
+            hook_events: &self.spec.hook_events,
+            hook_matcher: self.spec.hook_matcher.as_ref(),
         };
 
         let yaml = serde_yaml::to_string(&fm)?;
@@ -176,7 +182,12 @@ impl ToolCard {
         Ok(format!("---\n{yaml}---\n{body}"))
     }
 
-    pub fn pull_artifacts(&self, install_dir: PathBuf) -> Result<PathBuf, ToolError> {
+    pub fn pull_artifacts(
+        &self,
+        install_dir: PathBuf,
+        hook_installer: Option<&dyn super::installer::HookInstaller>,
+        global: bool,
+    ) -> Result<PathBuf, ToolError> {
         if self.name.is_empty()
             || !self
                 .name
@@ -234,6 +245,31 @@ impl ToolCard {
                 let path = install_dir.join(format!("{}-api.yaml", self.name));
                 let yaml_content = serde_yaml::to_string(&self.spec)?;
                 std::fs::write(&path, yaml_content)?;
+                Ok(path)
+            }
+            ToolType::Hook => {
+                let hook_dir = install_dir.join(".opsml/hooks");
+                std::fs::create_dir_all(&hook_dir)?;
+                let path = hook_dir.join(format!("{}.sh", self.name));
+                std::fs::write(&path, body_content)?;
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    let mut perms = std::fs::metadata(&path)?.permissions();
+                    perms.set_mode(0o755);
+                    std::fs::set_permissions(&path, perms)?;
+                }
+                let relative_path =
+                    PathBuf::from(format!(".opsml/hooks/{}.sh", self.name));
+                if let Some(installer) = hook_installer {
+                    installer.install_hook(
+                        &self.name,
+                        &relative_path,
+                        &self.spec.hook_events,
+                        self.spec.hook_matcher.as_ref(),
+                        global,
+                    )?;
+                }
                 Ok(path)
             }
             ToolType::InternalFunction | ToolType::Custom(_) => {
@@ -341,7 +377,7 @@ impl ProfileExt for ToolCard {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use opsml_types::contracts::tool::{ApiCallConfig, ShellScriptConfig};
+    use opsml_types::contracts::tool::{ApiCallConfig, HookEvent, ShellScriptConfig};
 
     fn make_spec() -> ToolSpec {
         ToolSpec {
@@ -523,7 +559,9 @@ mod tests {
             ToolCard::new_rs(spec, Some("test-space"), Some("my-tool"), None, None).unwrap();
         card.body = Some("#!/bin/bash\necho hello\n".to_string());
 
-        let path = card.pull_artifacts(tmp.path().to_path_buf()).unwrap();
+        let path = card
+            .pull_artifacts(tmp.path().to_path_buf(), None, false)
+            .unwrap();
         assert!(path.exists());
         assert!(path.to_str().unwrap().ends_with(".sh"));
         let content = std::fs::read_to_string(&path).unwrap();
@@ -538,7 +576,9 @@ mod tests {
             ToolCard::new_rs(spec, Some("test-space"), Some("my-slash"), None, None).unwrap();
         card.body = Some("Run the linter.\n".to_string());
 
-        let path = card.pull_artifacts(tmp.path().to_path_buf()).unwrap();
+        let path = card
+            .pull_artifacts(tmp.path().to_path_buf(), None, false)
+            .unwrap();
         assert!(path.exists());
         assert!(path.to_str().unwrap().ends_with(".md"));
         let content = std::fs::read_to_string(&path).unwrap();
@@ -554,7 +594,9 @@ mod tests {
         let card =
             ToolCard::new_rs(spec, Some("test-space"), Some("my-mcp"), None, None).unwrap();
 
-        let path = card.pull_artifacts(tmp.path().to_path_buf()).unwrap();
+        let path = card
+            .pull_artifacts(tmp.path().to_path_buf(), None, false)
+            .unwrap();
         assert!(path.exists());
         assert!(path.to_str().unwrap().ends_with("-mcp.json"));
     }
@@ -566,7 +608,9 @@ mod tests {
         let card =
             ToolCard::new_rs(spec, Some("test-space"), Some("my-api"), None, None).unwrap();
 
-        let path = card.pull_artifacts(tmp.path().to_path_buf()).unwrap();
+        let path = card
+            .pull_artifacts(tmp.path().to_path_buf(), None, false)
+            .unwrap();
         assert!(path.exists());
         assert!(path.to_str().unwrap().ends_with("-api.yaml"));
     }
@@ -631,7 +675,9 @@ mod tests {
             ..Default::default()
         };
         let card = ToolCard::new_rs(spec, Some("s"), Some("my-func"), None, None).unwrap();
-        let output = card.pull_artifacts(tmp.path().to_path_buf()).unwrap();
+        let output = card
+            .pull_artifacts(tmp.path().to_path_buf(), None, false)
+            .unwrap();
         assert!(output.exists());
         assert!(output.to_string_lossy().ends_with("-spec.yaml"));
     }
@@ -646,7 +692,9 @@ mod tests {
             ..Default::default()
         };
         let card = ToolCard::new_rs(spec, Some("s"), Some("my-custom"), None, None).unwrap();
-        let output = card.pull_artifacts(tmp.path().to_path_buf()).unwrap();
+        let output = card
+            .pull_artifacts(tmp.path().to_path_buf(), None, false)
+            .unwrap();
         assert!(output.exists());
         assert!(output.to_string_lossy().ends_with("-spec.yaml"));
     }
@@ -667,5 +715,48 @@ mod tests {
         assert_eq!(loaded.name, card.name);
         assert_eq!(loaded.spec.description, card.spec.description);
         assert_eq!(loaded.body, card.body);
+    }
+
+    #[test]
+    fn test_pull_hook_writes_script_and_sets_executable() {
+        let tmp = tempfile::tempdir().unwrap();
+        let spec = ToolSpec {
+            name: "my-hook".to_string(),
+            description: "A hook".to_string(),
+            tool_type: ToolType::Hook,
+            hook_events: vec![HookEvent::PostToolUse],
+            ..Default::default()
+        };
+        let mut card = ToolCard::new_rs(spec, Some("s"), Some("my-hook"), None, None).unwrap();
+        card.body = Some("#!/bin/bash\necho hook\n".to_string());
+
+        let path = card
+            .pull_artifacts(tmp.path().to_path_buf(), None, false)
+            .unwrap();
+        assert!(path.exists());
+        assert!(path.to_string_lossy().ends_with(".sh"));
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let perms = std::fs::metadata(&path).unwrap().permissions();
+            assert_eq!(perms.mode() & 0o777, 0o755);
+        }
+    }
+
+    #[test]
+    fn test_pull_hook_no_installer_still_writes_script() {
+        let tmp = tempfile::tempdir().unwrap();
+        let spec = ToolSpec {
+            name: "no-installer".to_string(),
+            description: "Hook without installer".to_string(),
+            tool_type: ToolType::Hook,
+            ..Default::default()
+        };
+        let card = ToolCard::new_rs(spec, Some("s"), Some("no-installer"), None, None).unwrap();
+        let path = card
+            .pull_artifacts(tmp.path().to_path_buf(), None, false)
+            .unwrap();
+        assert!(path.exists());
     }
 }

--- a/crates/opsml_cards/src/tool/error.rs
+++ b/crates/opsml_cards/src/tool/error.rs
@@ -16,10 +16,19 @@ pub enum ToolError {
 
     #[error(transparent)]
     UtilError(#[from] opsml_utils::error::UtilError),
+
+    #[error("TOML serialization error: {0}")]
+    TomlError(String),
 }
 
 impl From<ToolError> for crate::error::CardError {
     fn from(err: ToolError) -> Self {
         crate::error::CardError::Error(err.to_string())
+    }
+}
+
+impl From<toml::ser::Error> for ToolError {
+    fn from(err: toml::ser::Error) -> Self {
+        ToolError::TomlError(err.to_string())
     }
 }

--- a/crates/opsml_cards/src/tool/installer.rs
+++ b/crates/opsml_cards/src/tool/installer.rs
@@ -1,5 +1,8 @@
 use super::error::ToolError;
+use opsml_types::contracts::tool::HookEvent;
+use serde_json::Value;
 use std::path::{Path, PathBuf};
+use tracing::warn;
 
 pub trait SlashCommandInstaller {
     fn command_dir(&self) -> PathBuf;
@@ -48,6 +51,94 @@ pub(crate) fn default_merge_mcp_entry(
     Ok(())
 }
 
+fn read_json_or_default(path: &Path) -> Value {
+    if path.exists() {
+        match std::fs::read_to_string(path) {
+            Ok(content) => match serde_json::from_str::<Value>(&content) {
+                Ok(v) => v,
+                Err(e) => {
+                    warn!("Failed to parse {}: {e} — starting with empty config", path.display());
+                    Value::Object(serde_json::Map::new())
+                }
+            },
+            Err(e) => {
+                warn!("Failed to read {}: {e} — starting with empty config", path.display());
+                Value::Object(serde_json::Map::new())
+            }
+        }
+    } else {
+        Value::Object(serde_json::Map::new())
+    }
+}
+
+fn write_json(path: &Path, value: &Value) -> Result<(), ToolError> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
+    let content = serde_json::to_string_pretty(value)?;
+    std::fs::write(path, content)?;
+    Ok(())
+}
+
+fn command_exists_in_arr(arr: &Value, script_path: &Path) -> bool {
+    let script_str = script_path.to_string_lossy();
+    arr.as_array()
+        .map(|entries| {
+            entries.iter().any(|entry| {
+                entry
+                    .get("hooks")
+                    .and_then(|h| h.as_array())
+                    .map(|hooks| {
+                        hooks.iter().any(|h| {
+                            h.get("command")
+                                .and_then(|c| c.as_str())
+                                .map(|c| c == script_str)
+                                .unwrap_or(false)
+                        })
+                    })
+                    .unwrap_or(false)
+            })
+        })
+        .unwrap_or(false)
+}
+
+fn script_exists_in_arr(arr: &Value, script_path: &Path) -> bool {
+    let script_str = script_path.to_string_lossy();
+    arr.as_array()
+        .map(|entries| {
+            entries.iter().any(|entry| {
+                entry
+                    .get("script")
+                    .and_then(|s| s.as_str())
+                    .map(|s| s == script_str)
+                    .unwrap_or(false)
+            })
+        })
+        .unwrap_or(false)
+}
+
+fn hook_event_snake_case(e: &HookEvent) -> &'static str {
+    match e {
+        HookEvent::PreToolUse => "pre_tool_use",
+        HookEvent::PostToolUse => "post_tool_use",
+        HookEvent::Stop => "stop",
+        HookEvent::Notification => "notification",
+    }
+}
+
+pub trait HookInstaller {
+    fn install_hook(
+        &self,
+        name: &str,
+        script_path: &Path,
+        events: &[HookEvent],
+        matcher: Option<&Value>,
+        global: bool,
+    ) -> Result<(), ToolError>;
+}
+
 // ClaudeCodeInstaller
 
 pub struct ClaudeCodeInstaller;
@@ -71,6 +162,66 @@ impl McpConfigInstaller for ClaudeCodeInstaller {
 
     fn merge_mcp_entry(&self, name: &str, entry: serde_json::Value) -> Result<(), ToolError> {
         default_merge_mcp_entry(&self.mcp_config_path(), name, entry)
+    }
+}
+
+impl HookInstaller for ClaudeCodeInstaller {
+    fn install_hook(
+        &self,
+        _name: &str,
+        script_path: &Path,
+        events: &[HookEvent],
+        matcher: Option<&Value>,
+        global: bool,
+    ) -> Result<(), ToolError> {
+        let settings_path = if global {
+            dirs::home_dir()
+                .ok_or_else(|| ToolError::Error("Could not determine home directory".to_string()))?
+                .join(".claude/settings.json")
+        } else {
+            PathBuf::from(".claude/settings.json")
+        };
+
+        let mut settings = read_json_or_default(&settings_path);
+        let hooks_obj = settings
+            .as_object_mut()
+            .ok_or_else(|| ToolError::Error("settings.json root is not an object".to_string()))?
+            .entry("hooks")
+            .or_insert_with(|| Value::Object(serde_json::Map::new()));
+        let hooks_obj = hooks_obj
+            .as_object_mut()
+            .ok_or_else(|| ToolError::Error("hooks is not an object".to_string()))?;
+
+        let script_str = script_path.to_string_lossy().to_string();
+        let hook_entry = serde_json::json!({
+            "type": "command",
+            "command": script_str
+        });
+        let new_entry = serde_json::json!({
+            "matcher": matcher.cloned().unwrap_or(Value::Null),
+            "hooks": [hook_entry]
+        });
+
+        for event in events {
+            let key = match event {
+                HookEvent::PreToolUse => "PreToolUse",
+                HookEvent::PostToolUse => "PostToolUse",
+                HookEvent::Stop => "Stop",
+                HookEvent::Notification => "Notification",
+            };
+            let arr = hooks_obj
+                .entry(key)
+                .or_insert_with(|| Value::Array(vec![]));
+            if !command_exists_in_arr(arr, script_path) {
+                arr.as_array_mut()
+                    .ok_or_else(|| {
+                        ToolError::Error("hooks event array is not an array".to_string())
+                    })?
+                    .push(new_entry.clone());
+            }
+        }
+
+        write_json(&settings_path, &settings)
     }
 }
 
@@ -100,6 +251,57 @@ impl McpConfigInstaller for GeminiCliInstaller {
     }
 }
 
+impl HookInstaller for GeminiCliInstaller {
+    fn install_hook(
+        &self,
+        _name: &str,
+        script_path: &Path,
+        events: &[HookEvent],
+        matcher: Option<&Value>,
+        global: bool,
+    ) -> Result<(), ToolError> {
+        let settings_path = if global {
+            dirs::home_dir()
+                .ok_or_else(|| ToolError::Error("Could not determine home directory".to_string()))?
+                .join(".gemini/settings.json")
+        } else {
+            PathBuf::from(".gemini/settings.json")
+        };
+
+        let mut settings = read_json_or_default(&settings_path);
+        let hooks_obj = settings
+            .as_object_mut()
+            .ok_or_else(|| ToolError::Error("settings.json root is not an object".to_string()))?
+            .entry("hooks")
+            .or_insert_with(|| Value::Object(serde_json::Map::new()));
+        let hooks_obj = hooks_obj
+            .as_object_mut()
+            .ok_or_else(|| ToolError::Error("hooks is not an object".to_string()))?;
+
+        let script_str = script_path.to_string_lossy().to_string();
+        let new_entry = serde_json::json!({
+            "script": script_str,
+            "matcher": matcher.cloned().unwrap_or(Value::Null)
+        });
+
+        for event in events {
+            let key = hook_event_snake_case(event);
+            let arr = hooks_obj
+                .entry(key)
+                .or_insert_with(|| Value::Array(vec![]));
+            if !script_exists_in_arr(arr, script_path) {
+                arr.as_array_mut()
+                    .ok_or_else(|| {
+                        ToolError::Error("hooks event array is not an array".to_string())
+                    })?
+                    .push(new_entry.clone());
+            }
+        }
+
+        write_json(&settings_path, &settings)
+    }
+}
+
 // CodexInstaller
 
 pub struct CodexInstaller;
@@ -126,6 +328,79 @@ impl McpConfigInstaller for CodexInstaller {
     }
 }
 
+impl HookInstaller for CodexInstaller {
+    fn install_hook(
+        &self,
+        _name: &str,
+        script_path: &Path,
+        events: &[HookEvent],
+        matcher: Option<&Value>,
+        global: bool,
+    ) -> Result<(), ToolError> {
+        let config_path = if global {
+            dirs::home_dir()
+                .ok_or_else(|| ToolError::Error("Could not determine home directory".to_string()))?
+                .join(".codex/config.yaml")
+        } else {
+            PathBuf::from(".codex/config.yaml")
+        };
+
+        let mut config: Value = if config_path.exists() {
+            let content = std::fs::read_to_string(&config_path)?;
+            serde_yaml::from_str(&content)?
+        } else {
+            Value::Object(serde_json::Map::new())
+        };
+
+        let hooks_arr = config
+            .as_object_mut()
+            .ok_or_else(|| ToolError::Error("config.yaml root is not an object".to_string()))?
+            .entry("hooks")
+            .or_insert_with(|| Value::Array(vec![]));
+        let hooks_arr = hooks_arr
+            .as_array_mut()
+            .ok_or_else(|| ToolError::Error("hooks is not an array".to_string()))?;
+
+        let script_str = script_path.to_string_lossy().to_string();
+
+        for event in events {
+            let event_name = hook_event_snake_case(event);
+            let already_exists = hooks_arr.iter().any(|e| {
+                e.get("script")
+                    .and_then(|s| s.as_str())
+                    .map(|s| s == script_str)
+                    .unwrap_or(false)
+                    && e.get("event")
+                        .and_then(|ev| ev.as_str())
+                        .map(|ev| ev == event_name)
+                        .unwrap_or(false)
+            });
+            if !already_exists {
+                let mut entry = serde_json::json!({
+                    "event": event_name,
+                    "script": script_str,
+                });
+                if let Some(m) = matcher {
+                    entry
+                        .as_object_mut()
+                        .ok_or_else(|| ToolError::Error("hook entry is not an object".to_string()))?
+                        .insert("filter".to_string(), m.clone());
+                }
+                hooks_arr.push(entry);
+            }
+        }
+
+        if let Some(parent) = config_path.parent() {
+            if !parent.as_os_str().is_empty() {
+                std::fs::create_dir_all(parent)?;
+            }
+        }
+        let yaml_content = serde_yaml::to_string(&config)?;
+        std::fs::write(&config_path, yaml_content)?;
+        Ok(())
+    }
+}
+
 // CopilotInstaller
 
 pub struct CopilotInstaller;
@@ -149,6 +424,24 @@ impl McpConfigInstaller for CopilotInstaller {
 
     fn merge_mcp_entry(&self, name: &str, entry: serde_json::Value) -> Result<(), ToolError> {
         default_merge_mcp_entry(&self.mcp_config_path(), name, entry)
+    }
+}
+
+impl HookInstaller for CopilotInstaller {
+    fn install_hook(
+        &self,
+        _name: &str,
+        script_path: &Path,
+        _events: &[HookEvent],
+        _matcher: Option<&Value>,
+        _global: bool,
+    ) -> Result<(), ToolError> {
+        eprintln!(
+            "Warning: GitHub Copilot does not support lifecycle hooks. \
+             Script written to {}. Register it manually if needed.",
+            script_path.display()
+        );
+        Ok(())
     }
 }
 
@@ -220,5 +513,170 @@ mod tests {
         let config_path = tmp.path().join("nested/deep/.mcp.json");
         default_merge_mcp_entry(&config_path, "server", entry()).unwrap();
         assert!(config_path.exists());
+    }
+
+    // --- HookInstaller tests ---
+
+    use std::sync::Mutex;
+    static CWD_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_tempdir<F: FnOnce(&std::path::Path)>(f: F) {
+        let tmp = tempfile::tempdir().unwrap();
+        let _guard = CWD_LOCK.lock().unwrap();
+        let orig = std::env::current_dir().unwrap();
+        std::env::set_current_dir(tmp.path()).unwrap();
+        f(tmp.path());
+        std::env::set_current_dir(orig).unwrap();
+    }
+
+    #[test]
+    fn test_claude_code_hook_creates_settings_json() {
+        with_tempdir(|tmp| {
+            let script = Path::new(".opsml/hooks/my-hook.sh");
+            ClaudeCodeInstaller
+                .install_hook("my-hook", script, &[HookEvent::PostToolUse], None, false)
+                .unwrap();
+
+            let settings_path = tmp.join(".claude/settings.json");
+            assert!(settings_path.exists());
+            let content: Value =
+                serde_json::from_str(&std::fs::read_to_string(&settings_path).unwrap()).unwrap();
+            let hooks = &content["hooks"]["PostToolUse"];
+            assert!(hooks.is_array());
+            let arr = hooks.as_array().unwrap();
+            assert_eq!(arr.len(), 1);
+            assert_eq!(arr[0]["hooks"][0]["command"], ".opsml/hooks/my-hook.sh");
+        });
+    }
+
+    #[test]
+    fn test_claude_code_hook_idempotent() {
+        with_tempdir(|tmp| {
+            let script = Path::new(".opsml/hooks/my-hook.sh");
+            ClaudeCodeInstaller
+                .install_hook("my-hook", script, &[HookEvent::PostToolUse], None, false)
+                .unwrap();
+            ClaudeCodeInstaller
+                .install_hook("my-hook", script, &[HookEvent::PostToolUse], None, false)
+                .unwrap();
+
+            let settings_path = tmp.join(".claude/settings.json");
+            let content: Value =
+                serde_json::from_str(&std::fs::read_to_string(&settings_path).unwrap()).unwrap();
+            let arr = content["hooks"]["PostToolUse"].as_array().unwrap();
+            assert_eq!(arr.len(), 1, "idempotent: must not duplicate");
+        });
+    }
+
+    #[test]
+    fn test_claude_code_hook_multiple_events() {
+        with_tempdir(|tmp| {
+            let script = Path::new(".opsml/hooks/my-hook.sh");
+            ClaudeCodeInstaller
+                .install_hook(
+                    "my-hook",
+                    script,
+                    &[HookEvent::PostToolUse, HookEvent::PreToolUse],
+                    None,
+                    false,
+                )
+                .unwrap();
+
+            let settings_path = tmp.join(".claude/settings.json");
+            let content: Value =
+                serde_json::from_str(&std::fs::read_to_string(&settings_path).unwrap()).unwrap();
+            assert!(content["hooks"]["PostToolUse"].is_array());
+            assert!(content["hooks"]["PreToolUse"].is_array());
+        });
+    }
+
+    #[test]
+    fn test_gemini_hook_snake_case_keys() {
+        with_tempdir(|tmp| {
+            let script = Path::new(".opsml/hooks/my-hook.sh");
+            GeminiCliInstaller
+                .install_hook("my-hook", script, &[HookEvent::PostToolUse], None, false)
+                .unwrap();
+
+            let settings_path = tmp.join(".gemini/settings.json");
+            let content: Value =
+                serde_json::from_str(&std::fs::read_to_string(&settings_path).unwrap()).unwrap();
+            assert!(
+                content["hooks"]["post_tool_use"].is_array(),
+                "expected post_tool_use key"
+            );
+            assert!(
+                !content["hooks"]
+                    .as_object()
+                    .map(|o| o.contains_key("PostToolUse"))
+                    .unwrap_or(false)
+            );
+        });
+    }
+
+    #[test]
+    fn test_gemini_hook_idempotent() {
+        with_tempdir(|tmp| {
+            let script = Path::new(".opsml/hooks/my-hook.sh");
+            GeminiCliInstaller
+                .install_hook("my-hook", script, &[HookEvent::PostToolUse], None, false)
+                .unwrap();
+            GeminiCliInstaller
+                .install_hook("my-hook", script, &[HookEvent::PostToolUse], None, false)
+                .unwrap();
+
+            let settings_path = tmp.join(".gemini/settings.json");
+            let content: Value =
+                serde_json::from_str(&std::fs::read_to_string(&settings_path).unwrap()).unwrap();
+            let arr = content["hooks"]["post_tool_use"].as_array().unwrap();
+            assert_eq!(arr.len(), 1);
+        });
+    }
+
+    #[test]
+    fn test_codex_hook_yaml_format() {
+        with_tempdir(|tmp| {
+            let script = Path::new(".opsml/hooks/my-hook.sh");
+            CodexInstaller
+                .install_hook("my-hook", script, &[HookEvent::PostToolUse], None, false)
+                .unwrap();
+
+            let config_path = tmp.join(".codex/config.yaml");
+            assert!(config_path.exists());
+            let content = std::fs::read_to_string(&config_path).unwrap();
+            let parsed: Value = serde_yaml::from_str(&content).unwrap();
+            let hooks = parsed["hooks"].as_array().unwrap();
+            assert_eq!(hooks.len(), 1);
+            assert_eq!(hooks[0]["event"], "post_tool_use");
+            assert_eq!(hooks[0]["script"], ".opsml/hooks/my-hook.sh");
+        });
+    }
+
+    #[test]
+    fn test_codex_hook_idempotent() {
+        with_tempdir(|tmp| {
+            let script = Path::new(".opsml/hooks/my-hook.sh");
+            CodexInstaller
+                .install_hook("my-hook", script, &[HookEvent::PostToolUse], None, false)
+                .unwrap();
+            CodexInstaller
+                .install_hook("my-hook", script, &[HookEvent::PostToolUse], None, false)
+                .unwrap();
+
+            let config_path = tmp.join(".codex/config.yaml");
+            let content = std::fs::read_to_string(&config_path).unwrap();
+            let parsed: Value = serde_yaml::from_str(&content).unwrap();
+            let hooks = parsed["hooks"].as_array().unwrap();
+            assert_eq!(hooks.len(), 1, "idempotent");
+        });
+    }
+
+    #[test]
+    fn test_copilot_hook_returns_ok() {
+        let tmp = tempfile::tempdir().unwrap();
+        let script = tmp.path().join(".opsml/hooks/my-hook.sh");
+        let result =
+            CopilotInstaller.install_hook("my-hook", &script, &[HookEvent::PostToolUse], None, false);
+        assert!(result.is_ok());
     }
 }

--- a/crates/opsml_cards/src/tool/installer.rs
+++ b/crates/opsml_cards/src/tool/installer.rs
@@ -19,10 +19,10 @@ pub(crate) fn default_merge_mcp_entry(
     name: &str,
     entry: serde_json::Value,
 ) -> Result<(), ToolError> {
-    if let Some(parent) = mcp_config_path.parent() {
-        if !parent.as_os_str().is_empty() {
-            std::fs::create_dir_all(parent)?;
-        }
+    if let Some(parent) = mcp_config_path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent)?;
     }
 
     let existing = if mcp_config_path.exists() {
@@ -47,7 +47,7 @@ pub(crate) fn default_merge_mcp_entry(
         .insert(name.to_string(), entry);
 
     let content = serde_json::to_string_pretty(&root)?;
-    std::fs::write(&mcp_config_path, content)?;
+    std::fs::write(mcp_config_path, content)?;
     Ok(())
 }
 
@@ -72,10 +72,10 @@ fn read_json_or_default(path: &Path) -> Value {
 }
 
 fn write_json(path: &Path, value: &Value) -> Result<(), ToolError> {
-    if let Some(parent) = path.parent() {
-        if !parent.as_os_str().is_empty() {
-            std::fs::create_dir_all(parent)?;
-        }
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent)?;
     }
     let content = serde_json::to_string_pretty(value)?;
     std::fs::write(path, content)?;
@@ -390,10 +390,10 @@ impl HookInstaller for CodexInstaller {
             }
         }
 
-        if let Some(parent) = config_path.parent() {
-            if !parent.as_os_str().is_empty() {
-                std::fs::create_dir_all(parent)?;
-            }
+        if let Some(parent) = config_path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            std::fs::create_dir_all(parent)?;
         }
         let yaml_content = serde_yaml::to_string(&config)?;
         std::fs::write(&config_path, yaml_content)?;

--- a/crates/opsml_cards/src/tool/installer.rs
+++ b/crates/opsml_cards/src/tool/installer.rs
@@ -46,9 +46,7 @@ pub(crate) fn default_merge_mcp_entry(
         .ok_or_else(|| ToolError::Error("mcpServers is not an object".to_string()))?
         .insert(name.to_string(), entry);
 
-    let content = serde_json::to_string_pretty(&root)?;
-    std::fs::write(mcp_config_path, content)?;
-    Ok(())
+    write_json(mcp_config_path, &root)
 }
 
 fn read_json_or_default(path: &Path) -> Value {
@@ -57,12 +55,18 @@ fn read_json_or_default(path: &Path) -> Value {
             Ok(content) => match serde_json::from_str::<Value>(&content) {
                 Ok(v) => v,
                 Err(e) => {
-                    warn!("Failed to parse {}: {e} — starting with empty config", path.display());
+                    warn!(
+                        "Failed to parse {}: {e} — starting with empty config",
+                        path.display()
+                    );
                     Value::Object(serde_json::Map::new())
                 }
             },
             Err(e) => {
-                warn!("Failed to read {}: {e} — starting with empty config", path.display());
+                warn!(
+                    "Failed to read {}: {e} — starting with empty config",
+                    path.display()
+                );
                 Value::Object(serde_json::Map::new())
             }
         }
@@ -78,7 +82,9 @@ fn write_json(path: &Path, value: &Value) -> Result<(), ToolError> {
         std::fs::create_dir_all(parent)?;
     }
     let content = serde_json::to_string_pretty(value)?;
-    std::fs::write(path, content)?;
+    let tmp_path = path.with_extension("json.tmp");
+    std::fs::write(&tmp_path, &content)?;
+    std::fs::rename(&tmp_path, path)?;
     Ok(())
 }
 
@@ -119,12 +125,29 @@ fn script_exists_in_arr(arr: &Value, script_path: &Path) -> bool {
         .unwrap_or(false)
 }
 
-fn hook_event_snake_case(e: &HookEvent) -> &'static str {
-    match e {
-        HookEvent::PreToolUse => "pre_tool_use",
-        HookEvent::PostToolUse => "post_tool_use",
-        HookEvent::Stop => "stop",
-        HookEvent::Notification => "notification",
+pub(crate) fn validate_hook_matcher(v: &serde_json::Value) -> Result<(), ToolError> {
+    match v {
+        serde_json::Value::Null | serde_json::Value::String(_) => Ok(()),
+        serde_json::Value::Object(map) => {
+            if map.len() == 1
+                && let Some(tool_val) = map.get("tool")
+            {
+                match tool_val {
+                    serde_json::Value::String(_) => return Ok(()),
+                    serde_json::Value::Array(arr) if arr.iter().all(|v| v.is_string()) => {
+                        return Ok(());
+                    }
+                    _ => {}
+                }
+            }
+            Err(ToolError::Error(
+                "hook_matcher must be null, a string, or an object with a single 'tool' key mapping to a string or array of strings".to_string(),
+            ))
+        }
+        _ => Err(ToolError::Error(
+            "hook_matcher must be null, a string, or an object with a single 'tool' key"
+                .to_string(),
+        )),
     }
 }
 
@@ -174,6 +197,14 @@ impl HookInstaller for ClaudeCodeInstaller {
         matcher: Option<&Value>,
         global: bool,
     ) -> Result<(), ToolError> {
+        if events.is_empty() {
+            return Err(ToolError::Error(
+                "Hook tool has no hook_events configured; nothing to register".to_string(),
+            ));
+        }
+        if let Some(m) = matcher {
+            validate_hook_matcher(m)?;
+        }
         let settings_path = if global {
             dirs::home_dir()
                 .ok_or_else(|| ToolError::Error("Could not determine home directory".to_string()))?
@@ -203,15 +234,8 @@ impl HookInstaller for ClaudeCodeInstaller {
         });
 
         for event in events {
-            let key = match event {
-                HookEvent::PreToolUse => "PreToolUse",
-                HookEvent::PostToolUse => "PostToolUse",
-                HookEvent::Stop => "Stop",
-                HookEvent::Notification => "Notification",
-            };
-            let arr = hooks_obj
-                .entry(key)
-                .or_insert_with(|| Value::Array(vec![]));
+            let key = event.as_pascal_case();
+            let arr = hooks_obj.entry(key).or_insert_with(|| Value::Array(vec![]));
             if !command_exists_in_arr(arr, script_path) {
                 arr.as_array_mut()
                     .ok_or_else(|| {
@@ -260,6 +284,14 @@ impl HookInstaller for GeminiCliInstaller {
         matcher: Option<&Value>,
         global: bool,
     ) -> Result<(), ToolError> {
+        if events.is_empty() {
+            return Err(ToolError::Error(
+                "Hook tool has no hook_events configured; nothing to register".to_string(),
+            ));
+        }
+        if let Some(m) = matcher {
+            validate_hook_matcher(m)?;
+        }
         let settings_path = if global {
             dirs::home_dir()
                 .ok_or_else(|| ToolError::Error("Could not determine home directory".to_string()))?
@@ -285,10 +317,8 @@ impl HookInstaller for GeminiCliInstaller {
         });
 
         for event in events {
-            let key = hook_event_snake_case(event);
-            let arr = hooks_obj
-                .entry(key)
-                .or_insert_with(|| Value::Array(vec![]));
+            let key = event.as_snake_case();
+            let arr = hooks_obj.entry(key).or_insert_with(|| Value::Array(vec![]));
             if !script_exists_in_arr(arr, script_path) {
                 arr.as_array_mut()
                     .ok_or_else(|| {
@@ -337,6 +367,14 @@ impl HookInstaller for CodexInstaller {
         matcher: Option<&Value>,
         global: bool,
     ) -> Result<(), ToolError> {
+        if events.is_empty() {
+            return Err(ToolError::Error(
+                "Hook tool has no hook_events configured; nothing to register".to_string(),
+            ));
+        }
+        if let Some(m) = matcher {
+            validate_hook_matcher(m)?;
+        }
         let config_path = if global {
             dirs::home_dir()
                 .ok_or_else(|| ToolError::Error("Could not determine home directory".to_string()))?
@@ -364,7 +402,7 @@ impl HookInstaller for CodexInstaller {
         let script_str = script_path.to_string_lossy().to_string();
 
         for event in events {
-            let event_name = hook_event_snake_case(event);
+            let event_name = event.as_snake_case();
             let already_exists = hooks_arr.iter().any(|e| {
                 e.get("script")
                     .and_then(|s| s.as_str())
@@ -396,7 +434,9 @@ impl HookInstaller for CodexInstaller {
             std::fs::create_dir_all(parent)?;
         }
         let yaml_content = serde_yaml::to_string(&config)?;
-        std::fs::write(&config_path, yaml_content)?;
+        let tmp_path = config_path.with_extension("yaml.tmp");
+        std::fs::write(&tmp_path, &yaml_content)?;
+        std::fs::rename(&tmp_path, &config_path)?;
         Ok(())
     }
 }
@@ -436,9 +476,8 @@ impl HookInstaller for CopilotInstaller {
         _matcher: Option<&Value>,
         _global: bool,
     ) -> Result<(), ToolError> {
-        eprintln!(
-            "Warning: GitHub Copilot does not support lifecycle hooks. \
-             Script written to {}. Register it manually if needed.",
+        warn!(
+            "GitHub Copilot does not support lifecycle hooks. Script written to {}. Register it manually if needed.",
             script_path.display()
         );
         Ok(())
@@ -468,7 +507,13 @@ mod tests {
     #[test]
     fn test_gemini_cli_slash_command_dirs() {
         let installer = GeminiCliInstaller;
-        assert!(installer.command_dir().to_str().unwrap().contains(".gemini"));
+        assert!(
+            installer
+                .command_dir()
+                .to_str()
+                .unwrap()
+                .contains(".gemini")
+        );
         let global = installer.global_command_dir().unwrap();
         assert!(global.to_str().unwrap().contains(".gemini"));
     }
@@ -496,7 +541,13 @@ mod tests {
     #[test]
     fn test_copilot_slash_command_dirs() {
         let installer = CopilotInstaller;
-        assert!(installer.command_dir().to_str().unwrap().contains(".github"));
+        assert!(
+            installer
+                .command_dir()
+                .to_str()
+                .unwrap()
+                .contains(".github")
+        );
         let global = installer.global_command_dir().unwrap();
         assert!(global.to_str().unwrap().contains(".github"));
     }
@@ -517,20 +568,9 @@ mod tests {
 
     // --- HookInstaller tests ---
 
-    fn with_tempdir<F: FnOnce(&std::path::Path)>(f: F) {
-        let tmp = tempfile::tempdir().unwrap();
-        let _guard = crate::tool::test_util::CWD_LOCK
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
-        let orig = std::env::current_dir().unwrap();
-        std::env::set_current_dir(tmp.path()).unwrap();
-        f(tmp.path());
-        std::env::set_current_dir(orig).unwrap();
-    }
-
     #[test]
     fn test_claude_code_hook_creates_settings_json() {
-        with_tempdir(|tmp| {
+        crate::tool::test_util::with_tempdir(|tmp| {
             let script = Path::new(".opsml/hooks/my-hook.sh");
             ClaudeCodeInstaller
                 .install_hook("my-hook", script, &[HookEvent::PostToolUse], None, false)
@@ -550,7 +590,7 @@ mod tests {
 
     #[test]
     fn test_claude_code_hook_idempotent() {
-        with_tempdir(|tmp| {
+        crate::tool::test_util::with_tempdir(|tmp| {
             let script = Path::new(".opsml/hooks/my-hook.sh");
             ClaudeCodeInstaller
                 .install_hook("my-hook", script, &[HookEvent::PostToolUse], None, false)
@@ -569,7 +609,7 @@ mod tests {
 
     #[test]
     fn test_claude_code_hook_multiple_events() {
-        with_tempdir(|tmp| {
+        crate::tool::test_util::with_tempdir(|tmp| {
             let script = Path::new(".opsml/hooks/my-hook.sh");
             ClaudeCodeInstaller
                 .install_hook(
@@ -591,7 +631,7 @@ mod tests {
 
     #[test]
     fn test_gemini_hook_snake_case_keys() {
-        with_tempdir(|tmp| {
+        crate::tool::test_util::with_tempdir(|tmp| {
             let script = Path::new(".opsml/hooks/my-hook.sh");
             GeminiCliInstaller
                 .install_hook("my-hook", script, &[HookEvent::PostToolUse], None, false)
@@ -615,7 +655,7 @@ mod tests {
 
     #[test]
     fn test_gemini_hook_idempotent() {
-        with_tempdir(|tmp| {
+        crate::tool::test_util::with_tempdir(|tmp| {
             let script = Path::new(".opsml/hooks/my-hook.sh");
             GeminiCliInstaller
                 .install_hook("my-hook", script, &[HookEvent::PostToolUse], None, false)
@@ -634,7 +674,7 @@ mod tests {
 
     #[test]
     fn test_codex_hook_yaml_format() {
-        with_tempdir(|tmp| {
+        crate::tool::test_util::with_tempdir(|tmp| {
             let script = Path::new(".opsml/hooks/my-hook.sh");
             CodexInstaller
                 .install_hook("my-hook", script, &[HookEvent::PostToolUse], None, false)
@@ -653,7 +693,7 @@ mod tests {
 
     #[test]
     fn test_codex_hook_idempotent() {
-        with_tempdir(|tmp| {
+        crate::tool::test_util::with_tempdir(|tmp| {
             let script = Path::new(".opsml/hooks/my-hook.sh");
             CodexInstaller
                 .install_hook("my-hook", script, &[HookEvent::PostToolUse], None, false)
@@ -674,8 +714,83 @@ mod tests {
     fn test_copilot_hook_returns_ok() {
         let tmp = tempfile::tempdir().unwrap();
         let script = tmp.path().join(".opsml/hooks/my-hook.sh");
-        let result =
-            CopilotInstaller.install_hook("my-hook", &script, &[HookEvent::PostToolUse], None, false);
+        let result = CopilotInstaller.install_hook(
+            "my-hook",
+            &script,
+            &[HookEvent::PostToolUse],
+            None,
+            false,
+        );
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_claude_code_hook_with_matcher() {
+        crate::tool::test_util::with_tempdir(|_tmp| {
+            let installer = ClaudeCodeInstaller;
+            let script_path = std::path::Path::new(".opsml/hooks/my-hook.sh");
+            let matcher = serde_json::json!({"tool": "Write"});
+            installer
+                .install_hook(
+                    "my-hook",
+                    script_path,
+                    &[HookEvent::PostToolUse],
+                    Some(&matcher),
+                    false,
+                )
+                .unwrap();
+            let content = std::fs::read_to_string(".claude/settings.json").unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+            let entry = &parsed["hooks"]["PostToolUse"][0];
+            assert_eq!(entry["matcher"], serde_json::json!({"tool": "Write"}));
+        });
+    }
+
+    #[test]
+    fn test_install_hook_empty_events_returns_error() {
+        let installer = ClaudeCodeInstaller;
+        let tmp = tempfile::tempdir().unwrap();
+        let script_path = tmp.path().join("hook.sh");
+        let result = installer.install_hook("my-hook", &script_path, &[], None, false);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("hook_events"));
+    }
+
+    #[test]
+    fn test_claude_code_hook_global() {
+        let fake_home = tempfile::tempdir().unwrap();
+        let original_home = std::env::var("HOME").ok();
+        // SAFETY: test runs under --test-threads=1
+        unsafe { std::env::set_var("HOME", fake_home.path()) };
+        let result = std::panic::catch_unwind(|| {
+            let installer = ClaudeCodeInstaller;
+            let script_path = std::path::Path::new(".opsml/hooks/global-hook.sh");
+            installer
+                .install_hook(
+                    "global-hook",
+                    script_path,
+                    &[HookEvent::PostToolUse],
+                    None,
+                    true,
+                )
+                .unwrap();
+            let settings_path = fake_home.path().join(".claude/settings.json");
+            assert!(
+                settings_path.exists(),
+                "settings.json not created in fake home"
+            );
+            let content = std::fs::read_to_string(&settings_path).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+            assert!(parsed["hooks"]["PostToolUse"].is_array());
+        });
+        // SAFETY: test runs under --test-threads=1
+        unsafe {
+            if let Some(h) = original_home {
+                std::env::set_var("HOME", h);
+            } else {
+                std::env::remove_var("HOME");
+            }
+        }
+        result.unwrap();
     }
 }

--- a/crates/opsml_cards/src/tool/installer.rs
+++ b/crates/opsml_cards/src/tool/installer.rs
@@ -517,12 +517,11 @@ mod tests {
 
     // --- HookInstaller tests ---
 
-    use std::sync::Mutex;
-    static CWD_LOCK: Mutex<()> = Mutex::new(());
-
     fn with_tempdir<F: FnOnce(&std::path::Path)>(f: F) {
         let tmp = tempfile::tempdir().unwrap();
-        let _guard = CWD_LOCK.lock().unwrap();
+        let _guard = crate::tool::test_util::CWD_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let orig = std::env::current_dir().unwrap();
         std::env::set_current_dir(tmp.path()).unwrap();
         f(tmp.path());

--- a/crates/opsml_cards/src/tool/mod.rs
+++ b/crates/opsml_cards/src/tool/mod.rs
@@ -1,13 +1,25 @@
-pub mod card;
-pub mod error;
-pub mod installer;
+mod card;
+mod error;
+mod installer;
 
 pub use card::{ToolCard, parse_tool_markdown};
 pub use error::ToolError;
+pub use installer::{
+    ClaudeCodeInstaller, CodexInstaller, CopilotInstaller, GeminiCliInstaller, HookInstaller,
+    McpConfigInstaller, SlashCommandInstaller,
+};
 
 #[cfg(test)]
 pub(crate) mod test_util {
+    use std::path::Path;
     use std::sync::Mutex;
-    /// Single process-wide CWD lock shared by all tests in this module tree.
+
     pub(crate) static CWD_LOCK: Mutex<()> = Mutex::new(());
+
+    pub(crate) fn with_tempdir<F: FnOnce(&Path)>(f: F) {
+        let _guard = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::env::set_current_dir(tmp.path()).expect("set_current_dir");
+        f(tmp.path());
+    }
 }

--- a/crates/opsml_cards/src/tool/mod.rs
+++ b/crates/opsml_cards/src/tool/mod.rs
@@ -4,3 +4,10 @@ pub mod installer;
 
 pub use card::{ToolCard, parse_tool_markdown};
 pub use error::ToolError;
+
+#[cfg(test)]
+pub(crate) mod test_util {
+    use std::sync::Mutex;
+    /// Single process-wide CWD lock shared by all tests in this module tree.
+    pub(crate) static CWD_LOCK: Mutex<()> = Mutex::new(());
+}

--- a/crates/opsml_cards/src/tool/mod.rs
+++ b/crates/opsml_cards/src/tool/mod.rs
@@ -18,8 +18,12 @@ pub(crate) mod test_util {
 
     pub(crate) fn with_tempdir<F: FnOnce(&Path)>(f: F) {
         let _guard = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let orig = std::env::current_dir().ok();
         let tmp = tempfile::tempdir().expect("tempdir");
         std::env::set_current_dir(tmp.path()).expect("set_current_dir");
         f(tmp.path());
+        if let Some(orig) = orig {
+            let _ = std::env::set_current_dir(orig);
+        }
     }
 }

--- a/crates/opsml_cli/src/actions/mod.rs
+++ b/crates/opsml_cli/src/actions/mod.rs
@@ -11,9 +11,9 @@ pub mod ui;
 pub mod list;
 pub mod lock;
 pub mod register;
+pub mod tool;
 pub mod update_profile;
 pub mod utils;
-pub mod tool;
 pub mod validate;
 
 pub use download::{download_card, download_service};

--- a/crates/opsml_cli/src/actions/tool.rs
+++ b/crates/opsml_cli/src/actions/tool.rs
@@ -92,8 +92,18 @@ pub fn pull_tool(args: &ToolPullArgs) -> Result<(), CliError> {
     let card = opsml_cards::ToolCard::from_path(card_json)?;
 
     let output_dir = args.output.clone().unwrap_or_else(|| PathBuf::from("."));
+    let is_hook = matches!(
+        card.spec.tool_type,
+        opsml_types::contracts::tool::ToolType::Hook
+    );
+    if is_hook && args.target.is_none() {
+        return Err(CliError::Error(
+            "Hook tools require --target (claudecode|geminicli|codex|githubcopilot)".into(),
+        ));
+    }
+    let hook_installer = args.target.as_ref().map(|t| t.as_hook_installer());
     let installed_path = card
-        .pull_artifacts(output_dir, None, false)
+        .pull_artifacts(output_dir, hook_installer.as_deref(), args.global)
         .map_err(|e| CliError::Error(e.to_string()))?;
 
     println!(
@@ -175,6 +185,9 @@ pub fn init_tool(args: &ToolInitArgs) -> Result<(), CliError> {
         ),
         "mcp" => format!(
             "---\nname: {name}\ndescription: \"TODO: Describe what this MCP server does\"\ntoolType: McpServer\nmcpServerName: \"{name}\"\n---\n# {name}\n\nTODO: Describe the MCP server configuration here.\n"
+        ),
+        "hook" => format!(
+            "---\nname: {name}\ndescription: \"TODO: Describe what this hook does\"\ntoolType: Hook\nhookEvents:\n  - PostToolUse\nhookMatcher:\n  tool: Write\nrequiresApproval: false\n---\n#!/bin/bash\n# Hook body: runs after each Write tool call.\n"
         ),
         _ => format!(
             "---\nname: {name}\ndescription: \"TODO: Describe what this tool does\"\ntoolType: ShellScript\nscriptConfig:\n  script: \"echo hello\"\n  shell: \"/bin/bash\"\n---\n# {name}\n\nTODO: Write the shell script body here.\n"
@@ -288,6 +301,29 @@ mod tests {
             card.spec.tool_type,
             opsml_types::contracts::tool::ToolType::McpServer
         );
+    }
+
+    #[test]
+    fn test_init_tool_hook_creates_parseable_template() {
+        let tmp = tempfile::tempdir().unwrap();
+        let output = tmp.path().join("TOOL.md");
+
+        let args = ToolInitArgs {
+            name: Some("my-hook".to_string()),
+            output: Some(output.clone()),
+            tool_type: "hook".to_string(),
+        };
+        init_tool(&args).unwrap();
+
+        assert!(output.exists());
+        let content = std::fs::read_to_string(&output).unwrap();
+        let card = opsml_cards::parse_tool_markdown(&content).unwrap();
+        assert_eq!(card.spec.name, "my-hook");
+        assert_eq!(
+            card.spec.tool_type,
+            opsml_types::contracts::tool::ToolType::Hook
+        );
+        assert!(!card.spec.hook_events.is_empty());
     }
 
     #[test]

--- a/crates/opsml_cli/src/actions/tool.rs
+++ b/crates/opsml_cli/src/actions/tool.rs
@@ -93,7 +93,7 @@ pub fn pull_tool(args: &ToolPullArgs) -> Result<(), CliError> {
 
     let output_dir = args.output.clone().unwrap_or_else(|| PathBuf::from("."));
     let installed_path = card
-        .pull_artifacts(output_dir)
+        .pull_artifacts(output_dir, None, false)
         .map_err(|e| CliError::Error(e.to_string()))?;
 
     println!(

--- a/crates/opsml_cli/src/actions/tool.rs
+++ b/crates/opsml_cli/src/actions/tool.rs
@@ -120,10 +120,7 @@ pub fn pull_tool(args: &ToolPullArgs) -> Result<(), CliError> {
 
 #[instrument(skip_all)]
 pub fn list_tools(args: &ToolListArgs) -> Result<(), CliError> {
-    println!(
-        "\nListing cards from {} registry",
-        Colorize::green("tool")
-    );
+    println!("\nListing cards from {} registry", Colorize::green("tool"));
 
     let space = args.space.clone().map(|s| clean_string(&s)).transpose()?;
     let name = args.name.clone().map(|n| clean_string(&n)).transpose()?;
@@ -138,14 +135,14 @@ pub fn list_tools(args: &ToolListArgs) -> Result<(), CliError> {
         ..Default::default()
     };
 
-    let registry =
-        opsml_registry::registries::card::OpsmlCardRegistry::new(RegistryType::Tool)?;
+    let registry = opsml_registry::registries::card::OpsmlCardRegistry::new(RegistryType::Tool)?;
     let mut cards = registry.list_cards(&query_args)?;
 
     if let Some(tool_type) = &args.tool_type {
+        let filter = tool_type.to_string();
         cards.retain(|c| {
             if let opsml_types::contracts::CardRecord::Tool(r) = c {
-                &r.tool_type == tool_type
+                r.tool_type == filter
             } else {
                 false
             }
@@ -359,7 +356,7 @@ mod tests {
         let filter = "SlashCommand".to_string();
         cards.retain(|c| {
             if let CardRecord::Tool(r) = c {
-                &r.tool_type == &filter
+                r.tool_type == filter
             } else {
                 false
             }
@@ -377,7 +374,7 @@ mod tests {
         let wrong_case = "slashcommand".to_string();
         cards2.retain(|c| {
             if let CardRecord::Tool(r) = c {
-                &r.tool_type == &wrong_case
+                r.tool_type == wrong_case
             } else {
                 false
             }

--- a/crates/opsml_cli/src/cli/arg.rs
+++ b/crates/opsml_cli/src/cli/arg.rs
@@ -351,6 +351,15 @@ impl PullTarget {
             Self::GithubCopilot => Box::new(opsml_cards::CopilotInstaller),
         }
     }
+
+    pub fn as_hook_installer(&self) -> Box<dyn opsml_cards::HookInstaller> {
+        match self {
+            Self::ClaudeCode => Box::new(opsml_cards::ClaudeCodeInstaller),
+            Self::Codex => Box::new(opsml_cards::CodexInstaller),
+            Self::GeminiCli => Box::new(opsml_cards::GeminiCliInstaller),
+            Self::GithubCopilot => Box::new(opsml_cards::CopilotInstaller),
+        }
+    }
 }
 
 #[derive(Args, Clone)]
@@ -601,6 +610,12 @@ pub struct ToolPullArgs {
     /// Output directory (defaults to current directory)
     #[arg(long = "output")]
     pub output: Option<PathBuf>,
+    /// Target CLI for hook registration (required for Hook tools)
+    #[arg(long = "target")]
+    pub target: Option<PullTarget>,
+    /// Register hook globally (~/.claude/settings.json etc.) instead of project-local
+    #[arg(long = "global", default_value_t = false)]
+    pub global: bool,
 }
 
 #[derive(Args, Clone)]

--- a/crates/opsml_cli/src/cli/arg.rs
+++ b/crates/opsml_cli/src/cli/arg.rs
@@ -20,6 +20,23 @@ fn parse_version_type(s: &str) -> Result<VersionType, String> {
     })
 }
 
+fn parse_tool_type(s: &str) -> Result<opsml_types::contracts::tool::ToolType, String> {
+    use opsml_types::contracts::tool::ToolType;
+    match s {
+        "ShellScript" | "shell_script" | "shell-script" => Ok(ToolType::ShellScript),
+        "McpServer" | "mcp_server" | "mcp-server" => Ok(ToolType::McpServer),
+        "ApiCall" | "api_call" | "api-call" => Ok(ToolType::ApiCall),
+        "InternalFunction" | "internal_function" | "internal-function" => {
+            Ok(ToolType::InternalFunction)
+        }
+        "SlashCommand" | "slash_command" | "slash-command" => Ok(ToolType::SlashCommand),
+        "Hook" | "hook" => Ok(ToolType::Hook),
+        other => Err(format!(
+            "unknown tool type '{other}'; valid values: ShellScript, McpServer, ApiCall, InternalFunction, SlashCommand, Hook"
+        )),
+    }
+}
+
 fn default_spec_path() -> String {
     let path = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     let joined = path.join(DEFAULT_SERVICE_FILENAME);
@@ -629,9 +646,9 @@ pub struct ToolListArgs {
     /// Filter by tags (comma-separated)
     #[arg(long = "tags", use_value_delimiter = true, value_delimiter = ',')]
     pub tags: Option<Vec<String>>,
-    /// Filter by tool type (ShellScript, SlashCommand, McpServer, ApiCall, InternalFunction)
-    #[arg(long = "type")]
-    pub tool_type: Option<String>,
+    /// Filter by tool type (ShellScript, SlashCommand, McpServer, ApiCall, InternalFunction, Hook)
+    #[arg(long = "type", value_parser = parse_tool_type)]
+    pub tool_type: Option<opsml_types::contracts::tool::ToolType>,
     /// Maximum number of results
     #[arg(long = "limit")]
     pub limit: Option<i32>,

--- a/crates/opsml_mocks/src/mock.rs
+++ b/crates/opsml_mocks/src/mock.rs
@@ -36,6 +36,13 @@ pub struct ScouterServer {
 }
 
 #[cfg(feature = "server")]
+impl Default for ScouterServer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(feature = "server")]
 impl ScouterServer {
     pub fn new() -> Self {
         let mut server = mockito::Server::new();
@@ -258,9 +265,9 @@ impl OpsmlTestServer {
                 std::env::set_var("APP_ENV", "dev_server");
             }
 
-            if self.base_path.is_some() {
+            if let Some(base_path) = &self.base_path {
                 unsafe {
-                    std::env::set_var("OPSML_BASE_PATH", self.base_path.as_ref().unwrap());
+                    std::env::set_var("OPSML_BASE_PATH", base_path);
                 }
             }
 
@@ -302,7 +309,7 @@ impl OpsmlTestServer {
                     port
                 );
                 let res = client
-                    .get(&format!("http://localhost:{}/opsml/api/healthcheck", port))
+                    .get(format!("http://localhost:{}/opsml/api/healthcheck", port))
                     .send();
                 if let Ok(response) = res {
                     if response.status() == 200 {
@@ -333,7 +340,7 @@ impl OpsmlTestServer {
                 // set env vars for OPSML_TRACKING_URI
             }
 
-            return Err(TestServerError::ServerStartError.into());
+            Err(TestServerError::ServerStartError.into())
         }
         #[cfg(not(feature = "server"))]
         {

--- a/crates/opsml_registry/src/registries/card.rs
+++ b/crates/opsml_registry/src/registries/card.rs
@@ -76,7 +76,7 @@ impl OpsmlCardRegistry {
                         .await
                     })?;
 
-                    Ok(Self::Server(server_registry))
+                    Ok(Self::Server(Box::new(server_registry)))
                 }
                 #[cfg(not(feature = "server"))]
                 {

--- a/crates/opsml_registry/src/registries/card.rs
+++ b/crates/opsml_registry/src/registries/card.rs
@@ -36,7 +36,7 @@ pub enum OpsmlCardRegistry {
     Client(ClientCardRegistry),
 
     #[cfg(feature = "server")]
-    Server(ServerCardRegistry),
+    Server(Box<ServerCardRegistry>),
 }
 
 impl OpsmlCardRegistry {

--- a/crates/opsml_registry/src/registries/server/artifact.rs
+++ b/crates/opsml_registry/src/registries/server/artifact.rs
@@ -93,7 +93,7 @@ impl ServerArtifactRegistry {
         &self,
         query_args: &ArtifactQueryArgs,
     ) -> Result<Vec<ArtifactRecord>, RegistryError> {
-        let records = self.sql_client.query_artifacts(&query_args).await?;
+        let records = self.sql_client.query_artifacts(query_args).await?;
         Ok(records)
     }
 }

--- a/crates/opsml_registry/src/registries/server/experiment.rs
+++ b/crates/opsml_registry/src/registries/server/experiment.rs
@@ -52,7 +52,7 @@ impl ServerExperiment {
 
         let record = HardwareMetricsRecord {
             experiment_uid: metrics.experiment_uid.clone(),
-            created_at: created_at.clone(),
+            created_at,
             cpu_percent_utilization: metrics.metrics.cpu.cpu_percent_utilization,
             cpu_percent_per_core: SqlxJson(metrics.metrics.cpu.cpu_percent_per_core.clone()),
             free_memory: metrics.metrics.memory.free_memory,

--- a/crates/opsml_server/src/core/agentic/route.rs
+++ b/crates/opsml_server/src/core/agentic/route.rs
@@ -213,7 +213,12 @@ pub async fn get_skill_map(
             compatible_tools: vec![r.tool_type],
             download_count: r.download_count,
         };
-        if meta.compatible_tools.first().map(|t| t == "SlashCommand").unwrap_or(false) {
+        if meta
+            .compatible_tools
+            .first()
+            .map(|t| t == "SlashCommand")
+            .unwrap_or(false)
+        {
             commands.push(meta.clone());
         }
         tools.push(meta);

--- a/crates/opsml_server/src/core/cards/route.rs
+++ b/crates/opsml_server/src/core/cards/route.rs
@@ -407,11 +407,9 @@ pub async fn list_cards(
                 .map(convert_subagent_card)
                 .collect::<Vec<_>>(),
         ),
-        CardResults::Tool(data) => Json(
-            data.into_iter()
-                .map(convert_tool_card)
-                .collect::<Vec<_>>(),
-        ),
+        CardResults::Tool(data) => {
+            Json(data.into_iter().map(convert_tool_card).collect::<Vec<_>>())
+        }
     };
 
     // Create response and add audit context
@@ -443,9 +441,26 @@ pub async fn create_card(
     if let CardRecord::SubAgent(ref mut r) = card_request.card {
         r.username = perms.username.clone();
     }
+    if let CardRecord::Tool(ref mut r) = card_request.card {
+        r.username = perms.username.clone();
+    }
 
     if !perms.has_write_permission(card_request.card.space()) {
         return OpsmlServerError::permission_denied().into_response(StatusCode::FORBIDDEN);
+    }
+
+    // Size validation for ToolCard blobs
+    const MAX_SCHEMA_BYTES: usize = 64 * 1024;
+    if let CardRecord::Tool(ref r) = card_request.card
+        && let Some(schema) = &r.args_schema
+        && serde_json::to_vec(schema).map(|v| v.len()).unwrap_or(0) > MAX_SCHEMA_BYTES
+    {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(OpsmlServerError {
+                error: "args_schema exceeds maximum size of 64KB".to_string(),
+            }),
+        ));
     }
 
     // Run skill scan gate for SkillCards

--- a/crates/opsml_server/tests/api/tool_cli.rs
+++ b/crates/opsml_server/tests/api/tool_cli.rs
@@ -231,6 +231,69 @@ async fn test_v1_map_includes_tools() {
 }
 
 #[tokio::test]
+async fn test_tool_cli_push_and_list_hook() {
+    retry_flaky_test!({
+        let helper = TestHelper::new(None).await;
+
+        let resp = create_tool(&helper, "hook-tool", "repo1", "Hook", Some("A lifecycle hook".to_string())).await;
+        assert!(resp.registered);
+
+        let query = CardQueryArgs {
+            space: Some("repo1".to_string()),
+            name: Some("hook-tool".to_string()),
+            registry_type: RegistryType::Tool,
+            ..Default::default()
+        };
+        let cards = list_tools(&helper, &query).await;
+        assert_eq!(cards.len(), 1);
+        if let CardRecord::Tool(r) = &cards[0] {
+            assert_eq!(r.tool_type, "Hook");
+        } else {
+            panic!("expected Tool record");
+        }
+
+        helper.cleanup();
+    });
+}
+
+#[tokio::test]
+async fn test_v1_map_hook_not_in_commands() {
+    retry_flaky_test!({
+        let helper = TestHelper::new(None).await;
+
+        // Fixtures already include Tool4 (Hook) in repo1
+        let request = Request::builder()
+            .uri("/opsml/api/v1/map/repo1")
+            .method("GET")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = helper.send_oneshot(request).await;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let map: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+
+        let tools = map["tools"].as_array().expect("tools must be an array");
+        let commands = map["commands"].as_array().expect("commands must be an array");
+
+        // Tool4 (Hook) must appear in tools — compatible_tools[0] holds tool_type
+        let has_hook = tools
+            .iter()
+            .any(|t| t["compatible_tools"][0] == "Hook" && t["name"] == "Tool4");
+        assert!(has_hook, "Hook tool must appear in tools");
+
+        // Hook must NOT appear in commands (commands = SlashCommand only)
+        let hook_in_commands = commands
+            .iter()
+            .any(|c| c["compatible_tools"][0] == "Hook" || c["name"] == "Tool4");
+        assert!(!hook_in_commands, "Hook must not appear in commands");
+
+        helper.cleanup();
+    });
+}
+
+#[tokio::test]
 async fn test_v1_map_commands_are_slash_commands() {
     retry_flaky_test!({
         let helper = TestHelper::new(None).await;

--- a/crates/opsml_server/tests/api/tool_cli.rs
+++ b/crates/opsml_server/tests/api/tool_cli.rs
@@ -217,10 +217,7 @@ async fn test_v1_map_includes_tools() {
         let tools = body["tools"].as_array().expect("tools must be array");
         assert!(!tools.is_empty(), "repo1 should have fixture tools");
 
-        let names: Vec<&str> = tools
-            .iter()
-            .filter_map(|t| t["name"].as_str())
-            .collect();
+        let names: Vec<&str> = tools.iter().filter_map(|t| t["name"].as_str()).collect();
         assert!(
             names.contains(&"Tool1") || names.contains(&"Tool2") || names.contains(&"Tool3"),
             "expected at least one of Tool1/Tool2/Tool3 in tools"
@@ -235,7 +232,14 @@ async fn test_tool_cli_push_and_list_hook() {
     retry_flaky_test!({
         let helper = TestHelper::new(None).await;
 
-        let resp = create_tool(&helper, "hook-tool", "repo1", "Hook", Some("A lifecycle hook".to_string())).await;
+        let resp = create_tool(
+            &helper,
+            "hook-tool",
+            "repo1",
+            "Hook",
+            Some("A lifecycle hook".to_string()),
+        )
+        .await;
         assert!(resp.registered);
 
         let query = CardQueryArgs {
@@ -275,7 +279,9 @@ async fn test_v1_map_hook_not_in_commands() {
         let map: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
 
         let tools = map["tools"].as_array().expect("tools must be an array");
-        let commands = map["commands"].as_array().expect("commands must be an array");
+        let commands = map["commands"]
+            .as_array()
+            .expect("commands must be an array");
 
         // Tool4 (Hook) must appear in tools — compatible_tools[0] holds tool_type
         let has_hook = tools
@@ -312,27 +318,50 @@ async fn test_v1_map_commands_are_slash_commands() {
         let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
 
         let commands = body["commands"].as_array().expect("commands must be array");
-        assert!(!commands.is_empty(), "repo1 should have SlashCommand tools in commands");
+        assert!(
+            !commands.is_empty(),
+            "repo1 should have SlashCommand tools in commands"
+        );
 
         for cmd in commands {
             let compatible_tools = cmd["compatible_tools"]
                 .as_array()
                 .expect("compatible_tools must be array");
-            let tool_types: Vec<&str> = compatible_tools
-                .iter()
-                .filter_map(|t| t.as_str())
-                .collect();
+            let tool_types: Vec<&str> =
+                compatible_tools.iter().filter_map(|t| t.as_str()).collect();
             assert!(
                 tool_types.contains(&"SlashCommand"),
                 "commands array must only contain SlashCommand tools, got: {tool_types:?}"
             );
         }
 
-        let cmd_names: Vec<&str> = commands
-            .iter()
-            .filter_map(|c| c["name"].as_str())
-            .collect();
-        assert!(cmd_names.contains(&"Tool2"), "Tool2 (SlashCommand) must be in commands");
+        let cmd_names: Vec<&str> = commands.iter().filter_map(|c| c["name"].as_str()).collect();
+        assert!(
+            cmd_names.contains(&"Tool2"),
+            "Tool2 (SlashCommand) must be in commands"
+        );
+
+        helper.cleanup();
+    });
+}
+
+#[tokio::test]
+async fn test_get_tool_latest_not_found() {
+    retry_flaky_test!({
+        let helper = TestHelper::new(None).await;
+
+        let request = Request::builder()
+            .uri("/opsml/api/v1/tool/nonexistent/nonexistent-tool")
+            .method("GET")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = helper.send_oneshot(request).await;
+        assert_ne!(
+            response.status(),
+            StatusCode::OK,
+            "nonexistent tool must not return 200"
+        );
 
         helper.cleanup();
     });

--- a/crates/opsml_server/tests/fixtures/populate_db.sql
+++ b/crates/opsml_server/tests/fixtures/populate_db.sql
@@ -133,4 +133,8 @@ VALUES
     ('770e8400-e29b-41d4-a716-446655440003', '2023-11-28 00:00:00', 'development',
      'repo1', 'Tool3', 1, 0, 0, NULL, NULL, '1.0.0',
      '[]', 'McpServer',
-     NULL, 'An MCP server tool', NULL, '2.0.0', 'guest', 0);
+     NULL, 'An MCP server tool', NULL, '2.0.0', 'guest', 0),
+    ('770e8400-e29b-41d4-a716-446655440004', '2023-11-28 00:00:00', 'development',
+     'repo1', 'Tool4', 1, 0, 0, NULL, NULL, '1.0.0',
+     '[]', 'Hook',
+     NULL, 'A lifecycle hook', NULL, '2.0.0', 'guest', 0);

--- a/crates/opsml_sql/src/enums/client.rs
+++ b/crates/opsml_sql/src/enums/client.rs
@@ -868,15 +868,9 @@ impl ToolLogicTrait for SqlClientEnum {
         name: &str,
     ) -> Result<ToolCardRecord, SqlError> {
         match self {
-            SqlClientEnum::Postgres(client) => {
-                client.card.get_tool_card_by_name(space, name).await
-            }
-            SqlClientEnum::Sqlite(client) => {
-                client.card.get_tool_card_by_name(space, name).await
-            }
-            SqlClientEnum::MySql(client) => {
-                client.card.get_tool_card_by_name(space, name).await
-            }
+            SqlClientEnum::Postgres(client) => client.card.get_tool_card_by_name(space, name).await,
+            SqlClientEnum::Sqlite(client) => client.card.get_tool_card_by_name(space, name).await,
+            SqlClientEnum::MySql(client) => client.card.get_tool_card_by_name(space, name).await,
         }
     }
 
@@ -910,15 +904,9 @@ impl ToolLogicTrait for SqlClientEnum {
 
     async fn increment_tool_download_count(&self, uid: &str) -> Result<(), SqlError> {
         match self {
-            SqlClientEnum::Postgres(client) => {
-                client.card.increment_tool_download_count(uid).await
-            }
-            SqlClientEnum::Sqlite(client) => {
-                client.card.increment_tool_download_count(uid).await
-            }
-            SqlClientEnum::MySql(client) => {
-                client.card.increment_tool_download_count(uid).await
-            }
+            SqlClientEnum::Postgres(client) => client.card.increment_tool_download_count(uid).await,
+            SqlClientEnum::Sqlite(client) => client.card.increment_tool_download_count(uid).await,
+            SqlClientEnum::MySql(client) => client.card.increment_tool_download_count(uid).await,
         }
     }
 
@@ -946,9 +934,7 @@ impl ToolLogicTrait for SqlClientEnum {
         limit: i64,
     ) -> Result<Vec<ToolCardRecord>, SqlError> {
         match self {
-            SqlClientEnum::Postgres(client) => {
-                client.card.get_featured_tools(space, limit).await
-            }
+            SqlClientEnum::Postgres(client) => client.card.get_featured_tools(space, limit).await,
             SqlClientEnum::Sqlite(client) => client.card.get_featured_tools(space, limit).await,
             SqlClientEnum::MySql(client) => client.card.get_featured_tools(space, limit).await,
         }
@@ -962,17 +948,10 @@ impl ToolLogicTrait for SqlClientEnum {
         }
     }
 
-    async fn get_tool_marketplace_stats(
-        &self,
-        space: &str,
-    ) -> Result<MarketplaceStats, SqlError> {
+    async fn get_tool_marketplace_stats(&self, space: &str) -> Result<MarketplaceStats, SqlError> {
         match self {
-            SqlClientEnum::Postgres(client) => {
-                client.card.get_tool_marketplace_stats(space).await
-            }
-            SqlClientEnum::Sqlite(client) => {
-                client.card.get_tool_marketplace_stats(space).await
-            }
+            SqlClientEnum::Postgres(client) => client.card.get_tool_marketplace_stats(space).await,
+            SqlClientEnum::Sqlite(client) => client.card.get_tool_marketplace_stats(space).await,
             SqlClientEnum::MySql(client) => client.card.get_tool_marketplace_stats(space).await,
         }
     }

--- a/crates/opsml_sql/src/mysql/sql/card/mod.rs
+++ b/crates/opsml_sql/src/mysql/sql/card/mod.rs
@@ -484,10 +484,6 @@ impl CardLogicTrait for CardLogicMySqlClient {
             CardTable::Tool => match card {
                 ServerCard::Tool(record) => {
                     let query = MySqlQueryHelper::get_tool_card_insert_query();
-                    let args_schema_str = record
-                        .args_schema
-                        .as_ref()
-                        .map(|v| serde_json::to_string(v).unwrap());
                     sqlx::query(query)
                         .bind(&record.uid)
                         .bind(&record.app_env)
@@ -501,7 +497,7 @@ impl CardLogicTrait for CardLogicMySqlClient {
                         .bind(&record.build_tag)
                         .bind(&record.tags)
                         .bind(&record.tool_type)
-                        .bind(args_schema_str)
+                        .bind(&record.args_schema)
                         .bind(&record.description)
                         .bind(&record.content_hash)
                         .bind(&record.username)
@@ -728,17 +724,13 @@ impl CardLogicTrait for CardLogicMySqlClient {
             CardTable::Tool => match card {
                 ServerCard::Tool(record) => {
                     let query = MySqlQueryHelper::get_tool_card_update_query();
-                    let args_schema_str = record
-                        .args_schema
-                        .as_ref()
-                        .map(|v| serde_json::to_string(v).unwrap());
                     sqlx::query(query)
                         .bind(&record.app_env)
                         .bind(&record.name)
                         .bind(&record.space)
                         .bind(&record.tags)
                         .bind(&record.tool_type)
-                        .bind(args_schema_str)
+                        .bind(&record.args_schema)
                         .bind(&record.description)
                         .bind(&record.content_hash)
                         .bind(&record.username)

--- a/crates/opsml_sql/src/mysql/sql/card/mod.rs
+++ b/crates/opsml_sql/src/mysql/sql/card/mod.rs
@@ -1164,14 +1164,13 @@ impl ToolLogicTrait for CardLogicMySqlClient {
         space: &str,
         name: &str,
     ) -> Result<ToolCardRecord, SqlError> {
-        let record = sqlx::query_as::<_, ToolCardRecord>(
-            MySqlQueryHelper::get_tool_card_by_name_query(),
-        )
-        .bind(space)
-        .bind(name)
-        .fetch_optional(&self.pool)
-        .await?
-        .ok_or_else(|| SqlError::MissingField(format!("{}/{}", space, name)))?;
+        let record =
+            sqlx::query_as::<_, ToolCardRecord>(MySqlQueryHelper::get_tool_card_by_name_query())
+                .bind(space)
+                .bind(name)
+                .fetch_optional(&self.pool)
+                .await?
+                .ok_or_else(|| SqlError::MissingField(format!("{}/{}", space, name)))?;
         Ok(record)
     }
 
@@ -1181,15 +1180,14 @@ impl ToolLogicTrait for CardLogicMySqlClient {
         name: &str,
         version: &str,
     ) -> Result<ToolCardRecord, SqlError> {
-        let record = sqlx::query_as::<_, ToolCardRecord>(
-            MySqlQueryHelper::get_tool_card_by_version_query(),
-        )
-        .bind(space)
-        .bind(name)
-        .bind(version)
-        .fetch_optional(&self.pool)
-        .await?
-        .ok_or_else(|| SqlError::MissingField(format!("{}/{}/{}", space, name, version)))?;
+        let record =
+            sqlx::query_as::<_, ToolCardRecord>(MySqlQueryHelper::get_tool_card_by_version_query())
+                .bind(space)
+                .bind(name)
+                .bind(version)
+                .fetch_optional(&self.pool)
+                .await?
+                .ok_or_else(|| SqlError::MissingField(format!("{}/{}/{}", space, name, version)))?;
         Ok(record)
     }
 
@@ -1225,13 +1223,12 @@ impl ToolLogicTrait for CardLogicMySqlClient {
         space: &str,
         limit: i64,
     ) -> Result<Vec<ToolCardRecord>, SqlError> {
-        let records = sqlx::query_as::<_, ToolCardRecord>(
-            MySqlQueryHelper::get_featured_tools_query(),
-        )
-        .bind(space)
-        .bind(limit)
-        .fetch_all(&self.pool)
-        .await?;
+        let records =
+            sqlx::query_as::<_, ToolCardRecord>(MySqlQueryHelper::get_featured_tools_query())
+                .bind(space)
+                .bind(limit)
+                .fetch_all(&self.pool)
+                .await?;
         Ok(records)
     }
 
@@ -1243,10 +1240,7 @@ impl ToolLogicTrait for CardLogicMySqlClient {
         Ok(tags)
     }
 
-    async fn get_tool_marketplace_stats(
-        &self,
-        space: &str,
-    ) -> Result<MarketplaceStats, SqlError> {
+    async fn get_tool_marketplace_stats(&self, space: &str) -> Result<MarketplaceStats, SqlError> {
         let row: (i64, i64, i64) =
             sqlx::query_as(MySqlQueryHelper::get_tool_marketplace_stats_query())
                 .bind(space)

--- a/crates/opsml_sql/src/postgres/sql/card/mod.rs
+++ b/crates/opsml_sql/src/postgres/sql/card/mod.rs
@@ -442,10 +442,6 @@ impl CardLogicTrait for CardLogicPostgresClient {
             CardTable::Tool => match card {
                 ServerCard::Tool(record) => {
                     let query = PostgresQueryHelper::get_tool_card_insert_query();
-                    let args_schema_str = record
-                        .args_schema
-                        .as_ref()
-                        .map(|v| serde_json::to_string(v).unwrap());
                     sqlx::query(query)
                         .bind(&record.uid)
                         .bind(&record.app_env)
@@ -459,7 +455,7 @@ impl CardLogicTrait for CardLogicPostgresClient {
                         .bind(&record.build_tag)
                         .bind(&record.tags)
                         .bind(&record.tool_type)
-                        .bind(args_schema_str)
+                        .bind(&record.args_schema)
                         .bind(&record.description)
                         .bind(&record.content_hash)
                         .bind(&record.username)
@@ -687,17 +683,13 @@ impl CardLogicTrait for CardLogicPostgresClient {
             CardTable::Tool => match card {
                 ServerCard::Tool(record) => {
                     let query = PostgresQueryHelper::get_tool_card_update_query();
-                    let args_schema_str = record
-                        .args_schema
-                        .as_ref()
-                        .map(|v| serde_json::to_string(v).unwrap());
                     sqlx::query(query)
                         .bind(&record.app_env)
                         .bind(&record.name)
                         .bind(&record.space)
                         .bind(&record.tags)
                         .bind(&record.tool_type)
-                        .bind(args_schema_str)
+                        .bind(&record.args_schema)
                         .bind(&record.description)
                         .bind(&record.content_hash)
                         .bind(&record.username)

--- a/crates/opsml_sql/src/postgres/sql/card/mod.rs
+++ b/crates/opsml_sql/src/postgres/sql/card/mod.rs
@@ -1140,14 +1140,13 @@ impl ToolLogicTrait for CardLogicPostgresClient {
         space: &str,
         name: &str,
     ) -> Result<ToolCardRecord, SqlError> {
-        let record = sqlx::query_as::<_, ToolCardRecord>(
-            PostgresQueryHelper::get_tool_card_by_name_query(),
-        )
-        .bind(space)
-        .bind(name)
-        .fetch_optional(&self.pool)
-        .await?
-        .ok_or_else(|| SqlError::MissingField(format!("{}/{}", space, name)))?;
+        let record =
+            sqlx::query_as::<_, ToolCardRecord>(PostgresQueryHelper::get_tool_card_by_name_query())
+                .bind(space)
+                .bind(name)
+                .fetch_optional(&self.pool)
+                .await?
+                .ok_or_else(|| SqlError::MissingField(format!("{}/{}", space, name)))?;
         Ok(record)
     }
 
@@ -1170,11 +1169,10 @@ impl ToolLogicTrait for CardLogicPostgresClient {
     }
 
     async fn increment_tool_download_count(&self, uid: &str) -> Result<(), SqlError> {
-        let result =
-            sqlx::query(PostgresQueryHelper::get_increment_tool_download_count_query())
-                .bind(uid)
-                .execute(&self.pool)
-                .await?;
+        let result = sqlx::query(PostgresQueryHelper::get_increment_tool_download_count_query())
+            .bind(uid)
+            .execute(&self.pool)
+            .await?;
         if result.rows_affected() == 0 {
             return Err(SqlError::MissingField(format!("tool uid not found: {uid}")));
         }
@@ -1201,29 +1199,24 @@ impl ToolLogicTrait for CardLogicPostgresClient {
         space: &str,
         limit: i64,
     ) -> Result<Vec<ToolCardRecord>, SqlError> {
-        let records = sqlx::query_as::<_, ToolCardRecord>(
-            PostgresQueryHelper::get_featured_tools_query(),
-        )
-        .bind(space)
-        .bind(limit)
-        .fetch_all(&self.pool)
-        .await?;
+        let records =
+            sqlx::query_as::<_, ToolCardRecord>(PostgresQueryHelper::get_featured_tools_query())
+                .bind(space)
+                .bind(limit)
+                .fetch_all(&self.pool)
+                .await?;
         Ok(records)
     }
 
     async fn get_all_tool_tags(&self, space: &str) -> Result<Vec<String>, SqlError> {
-        let tags: Vec<String> =
-            sqlx::query_scalar(PostgresQueryHelper::get_all_tool_tags_query())
-                .bind(space)
-                .fetch_all(&self.pool)
-                .await?;
+        let tags: Vec<String> = sqlx::query_scalar(PostgresQueryHelper::get_all_tool_tags_query())
+            .bind(space)
+            .fetch_all(&self.pool)
+            .await?;
         Ok(tags)
     }
 
-    async fn get_tool_marketplace_stats(
-        &self,
-        space: &str,
-    ) -> Result<MarketplaceStats, SqlError> {
+    async fn get_tool_marketplace_stats(&self, space: &str) -> Result<MarketplaceStats, SqlError> {
         let row: (i64, i64, i64) =
             sqlx::query_as(PostgresQueryHelper::get_tool_marketplace_stats_query())
                 .bind(space)

--- a/crates/opsml_sql/src/schemas/schema.rs
+++ b/crates/opsml_sql/src/schemas/schema.rs
@@ -1846,9 +1846,7 @@ impl ServerCard {
             CardRecord::SubAgent(card) => Ok(ServerCard::SubAgent(
                 SubAgentCardRecord::from_client_card(card)?,
             )),
-            CardRecord::Tool(card) => {
-                Ok(ServerCard::Tool(ToolCardRecord::from_client_card(card)?))
-            }
+            CardRecord::Tool(card) => Ok(ServerCard::Tool(ToolCardRecord::from_client_card(card)?)),
         }
     }
 }

--- a/crates/opsml_sql/src/sqlite/client.rs
+++ b/crates/opsml_sql/src/sqlite/client.rs
@@ -104,7 +104,7 @@ mod tests {
     };
     use crate::traits::{
         ArtifactLogicTrait, AuditLogicTrait, CardLogicTrait, EvaluationLogicTrait,
-        ExperimentLogicTrait, SpaceLogicTrait, UserLogicTrait,
+        ExperimentLogicTrait, SpaceLogicTrait, ToolLogicTrait, UserLogicTrait,
     };
     use opsml_settings::config::DatabaseSettings;
     use opsml_types::SqlType;
@@ -2261,6 +2261,76 @@ mod tests {
         assert_eq!(deployment[0].urls.len(), 1);
         assert_eq!(deployment[0].urls[0], "http://localhost:8000");
         assert_eq!(deployment[0].healthcheck.as_deref(), Some("/health"));
+
+        cleanup();
+    }
+
+    #[tokio::test]
+    async fn test_tool_card_crud() {
+        cleanup();
+
+        let config = DatabaseSettings {
+            connection_uri: get_connection_uri(),
+            max_connections: 1,
+            sql_type: SqlType::Sqlite,
+        };
+
+        let client = SqliteClient::new(&config).await.unwrap();
+
+        let version = Version::new(0, 1, 0);
+        let record = ToolCardRecord::new(
+            "test-tool".to_string(),
+            SPACE.to_string(),
+            version,
+            vec!["ci".to_string()],
+            "ShellScript".to_string(),
+            None,
+            Some("A test tool".to_string()),
+            "0.0.0".to_string(),
+            "admin".to_string(),
+            None,
+        );
+
+        let uid = record.uid.clone();
+
+        client
+            .card
+            .insert_card(&CardTable::Tool, &ServerCard::Tool(record))
+            .await
+            .unwrap();
+
+        let fetched = client
+            .card
+            .get_tool_card_by_name(SPACE, "test-tool")
+            .await
+            .unwrap();
+        assert_eq!(fetched.name, "test-tool");
+        assert_eq!(fetched.space, SPACE);
+        assert_eq!(fetched.tool_type, "ShellScript");
+        assert_eq!(fetched.download_count, 0);
+
+        client
+            .card
+            .increment_tool_download_count(&uid)
+            .await
+            .unwrap();
+
+        let fetched2 = client
+            .card
+            .get_tool_card_by_name(SPACE, "test-tool")
+            .await
+            .unwrap();
+        assert_eq!(fetched2.download_count, 1);
+
+        let listed = client
+            .card
+            .list_tool_cards_by_space(SPACE, None)
+            .await
+            .unwrap();
+        assert!(
+            listed.iter().any(|r| r.name == "test-tool"),
+            "test-tool must appear in list"
+        );
 
         cleanup();
     }

--- a/crates/opsml_sql/src/sqlite/sql/card/mod.rs
+++ b/crates/opsml_sql/src/sqlite/sql/card/mod.rs
@@ -1174,14 +1174,13 @@ impl ToolLogicTrait for CardLogicSqliteClient {
         space: &str,
         name: &str,
     ) -> Result<ToolCardRecord, SqlError> {
-        let record = sqlx::query_as::<_, ToolCardRecord>(
-            SqliteQueryHelper::get_tool_card_by_name_query(),
-        )
-        .bind(space)
-        .bind(name)
-        .fetch_optional(&self.pool)
-        .await?
-        .ok_or_else(|| SqlError::MissingField(format!("{}/{}", space, name)))?;
+        let record =
+            sqlx::query_as::<_, ToolCardRecord>(SqliteQueryHelper::get_tool_card_by_name_query())
+                .bind(space)
+                .bind(name)
+                .fetch_optional(&self.pool)
+                .await?
+                .ok_or_else(|| SqlError::MissingField(format!("{}/{}", space, name)))?;
         Ok(record)
     }
 
@@ -1235,29 +1234,24 @@ impl ToolLogicTrait for CardLogicSqliteClient {
         space: &str,
         limit: i64,
     ) -> Result<Vec<ToolCardRecord>, SqlError> {
-        let records = sqlx::query_as::<_, ToolCardRecord>(
-            SqliteQueryHelper::get_featured_tools_query(),
-        )
-        .bind(space)
-        .bind(limit)
-        .fetch_all(&self.pool)
-        .await?;
+        let records =
+            sqlx::query_as::<_, ToolCardRecord>(SqliteQueryHelper::get_featured_tools_query())
+                .bind(space)
+                .bind(limit)
+                .fetch_all(&self.pool)
+                .await?;
         Ok(records)
     }
 
     async fn get_all_tool_tags(&self, space: &str) -> Result<Vec<String>, SqlError> {
-        let tags: Vec<String> =
-            sqlx::query_scalar(SqliteQueryHelper::get_all_tool_tags_query())
-                .bind(space)
-                .fetch_all(&self.pool)
-                .await?;
+        let tags: Vec<String> = sqlx::query_scalar(SqliteQueryHelper::get_all_tool_tags_query())
+            .bind(space)
+            .fetch_all(&self.pool)
+            .await?;
         Ok(tags)
     }
 
-    async fn get_tool_marketplace_stats(
-        &self,
-        space: &str,
-    ) -> Result<MarketplaceStats, SqlError> {
+    async fn get_tool_marketplace_stats(&self, space: &str) -> Result<MarketplaceStats, SqlError> {
         let row: (i64, i64, i64) =
             sqlx::query_as(SqliteQueryHelper::get_tool_marketplace_stats_query())
                 .bind(space)

--- a/crates/opsml_sql/src/sqlite/sql/card/mod.rs
+++ b/crates/opsml_sql/src/sqlite/sql/card/mod.rs
@@ -485,10 +485,6 @@ impl CardLogicTrait for CardLogicSqliteClient {
             CardTable::Tool => match card {
                 ServerCard::Tool(record) => {
                     let query = SqliteQueryHelper::get_tool_card_insert_query();
-                    let args_schema_str = record
-                        .args_schema
-                        .as_ref()
-                        .map(|v| serde_json::to_string(v).unwrap());
                     sqlx::query(query)
                         .bind(&record.uid)
                         .bind(&record.app_env)
@@ -502,7 +498,7 @@ impl CardLogicTrait for CardLogicSqliteClient {
                         .bind(&record.build_tag)
                         .bind(&record.tags)
                         .bind(&record.tool_type)
-                        .bind(args_schema_str)
+                        .bind(&record.args_schema)
                         .bind(&record.description)
                         .bind(&record.content_hash)
                         .bind(&record.username)
@@ -729,17 +725,13 @@ impl CardLogicTrait for CardLogicSqliteClient {
             CardTable::Tool => match card {
                 ServerCard::Tool(record) => {
                     let query = SqliteQueryHelper::get_tool_card_update_query();
-                    let args_schema_str = record
-                        .args_schema
-                        .as_ref()
-                        .map(|v| serde_json::to_string(v).unwrap());
                     sqlx::query(query)
                         .bind(&record.app_env)
                         .bind(&record.name)
                         .bind(&record.space)
                         .bind(&record.tags)
                         .bind(&record.tool_type)
-                        .bind(args_schema_str)
+                        .bind(&record.args_schema)
                         .bind(&record.description)
                         .bind(&record.content_hash)
                         .bind(&record.username)

--- a/crates/opsml_sql/src/traits/mod.rs
+++ b/crates/opsml_sql/src/traits/mod.rs
@@ -275,8 +275,5 @@ pub trait ToolLogicTrait {
 
     async fn get_all_tool_tags(&self, space: &str) -> Result<Vec<String>, SqlError>;
 
-    async fn get_tool_marketplace_stats(
-        &self,
-        space: &str,
-    ) -> Result<MarketplaceStats, SqlError>;
+    async fn get_tool_marketplace_stats(&self, space: &str) -> Result<MarketplaceStats, SqlError>;
 }

--- a/crates/opsml_types/src/contracts/tool.rs
+++ b/crates/opsml_types/src/contracts/tool.rs
@@ -10,6 +10,7 @@ pub enum ToolType {
     ApiCall,
     InternalFunction,
     SlashCommand,
+    Hook,
     Custom(String),
 }
 
@@ -21,6 +22,7 @@ impl std::fmt::Display for ToolType {
             ToolType::ApiCall => write!(f, "ApiCall"),
             ToolType::InternalFunction => write!(f, "InternalFunction"),
             ToolType::SlashCommand => write!(f, "SlashCommand"),
+            ToolType::Hook => write!(f, "Hook"),
             ToolType::Custom(s) => write!(f, "{s}"),
         }
     }
@@ -34,6 +36,7 @@ impl From<&str> for ToolType {
             "ApiCall" => ToolType::ApiCall,
             "InternalFunction" => ToolType::InternalFunction,
             "SlashCommand" => ToolType::SlashCommand,
+            "Hook" => ToolType::Hook,
             other => ToolType::Custom(other.to_string()),
         }
     }
@@ -88,6 +91,16 @@ impl Default for ApiCallConfig {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "PascalCase")]
+pub enum HookEvent {
+    #[default]
+    PostToolUse,
+    PreToolUse,
+    Stop,
+    Notification,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(default, rename_all = "camelCase")]
 pub struct ToolSpec {
@@ -107,6 +120,10 @@ pub struct ToolSpec {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub allowed_tools: Vec<String>,
     pub requires_approval: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub hook_events: Vec<HookEvent>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hook_matcher: Option<serde_json::Value>,
 }
 
 #[cfg(test)]
@@ -177,5 +194,37 @@ mod tests {
         let json = serde_json::to_string(&config).unwrap();
         let restored: ApiCallConfig = serde_json::from_str(&json).unwrap();
         assert_eq!(restored.method, "GET");
+    }
+
+    #[test]
+    fn test_hook_event_pascal_case() {
+        let json = serde_json::to_string(&HookEvent::PreToolUse).unwrap();
+        assert_eq!(json, "\"PreToolUse\"");
+    }
+
+    #[test]
+    fn test_tool_spec_hook_roundtrip() {
+        let spec = ToolSpec {
+            name: "my-hook".to_string(),
+            description: "A hook tool".to_string(),
+            tool_type: ToolType::Hook,
+            hook_events: vec![HookEvent::PostToolUse],
+            hook_matcher: Some(serde_json::json!({"tool": "Write"})),
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&spec).unwrap();
+        let restored: ToolSpec = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.name, spec.name);
+        assert_eq!(restored.tool_type, ToolType::Hook);
+        assert_eq!(restored.hook_events, vec![HookEvent::PostToolUse]);
+        assert_eq!(restored.hook_matcher, Some(serde_json::json!({"tool": "Write"})));
+    }
+
+    #[test]
+    fn test_hook_variant_does_not_break_existing_serde() {
+        let shell: ToolType = serde_json::from_str("\"ShellScript\"").unwrap();
+        assert_eq!(shell, ToolType::ShellScript);
+        let slash: ToolType = serde_json::from_str("\"SlashCommand\"").unwrap();
+        assert_eq!(slash, ToolType::SlashCommand);
     }
 }

--- a/crates/opsml_types/src/contracts/tool.rs
+++ b/crates/opsml_types/src/contracts/tool.rs
@@ -158,6 +158,7 @@ mod tests {
             (ToolType::ApiCall, "\"ApiCall\""),
             (ToolType::InternalFunction, "\"InternalFunction\""),
             (ToolType::SlashCommand, "\"SlashCommand\""),
+            (ToolType::Hook, "\"Hook\""),
         ];
         for (variant, expected_json) in variants {
             let json = serde_json::to_string(&variant).unwrap();

--- a/crates/opsml_types/src/contracts/tool.rs
+++ b/crates/opsml_types/src/contracts/tool.rs
@@ -91,6 +91,31 @@ impl Default for ApiCallConfig {
     }
 }
 
+impl ApiCallConfig {
+    pub fn sanitize_for_response(&self) -> Self {
+        const SENSITIVE_KEYS: &[&str] = &[
+            "authorization",
+            "x-api-key",
+            "x-auth-token",
+            "cookie",
+            "x-secret",
+            "proxy-authorization",
+        ];
+        let headers = self
+            .headers
+            .iter()
+            .filter(|(k, _)| !SENSITIVE_KEYS.contains(&k.to_lowercase().as_str()))
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        Self {
+            url: self.url.clone(),
+            method: self.method.clone(),
+            headers,
+            body_template: self.body_template.clone(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 #[serde(rename_all = "PascalCase")]
 pub enum HookEvent {
@@ -99,6 +124,26 @@ pub enum HookEvent {
     PreToolUse,
     Stop,
     Notification,
+}
+
+impl HookEvent {
+    pub fn as_snake_case(&self) -> &'static str {
+        match self {
+            HookEvent::PreToolUse => "pre_tool_use",
+            HookEvent::PostToolUse => "post_tool_use",
+            HookEvent::Stop => "stop",
+            HookEvent::Notification => "notification",
+        }
+    }
+
+    pub fn as_pascal_case(&self) -> &'static str {
+        match self {
+            HookEvent::PreToolUse => "PreToolUse",
+            HookEvent::PostToolUse => "PostToolUse",
+            HookEvent::Stop => "Stop",
+            HookEvent::Notification => "Notification",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -144,7 +189,10 @@ mod tests {
             ..Default::default()
         };
         let json = serde_json::to_string(&spec).unwrap();
-        assert!(json.contains("\"toolType\""), "expected camelCase 'toolType' key, got: {json}");
+        assert!(
+            json.contains("\"toolType\""),
+            "expected camelCase 'toolType' key, got: {json}"
+        );
         let restored: ToolSpec = serde_json::from_str(&json).unwrap();
         assert_eq!(restored.name, spec.name);
         assert_eq!(restored.tool_type, ToolType::ShellScript);
@@ -218,7 +266,10 @@ mod tests {
         assert_eq!(restored.name, spec.name);
         assert_eq!(restored.tool_type, ToolType::Hook);
         assert_eq!(restored.hook_events, vec![HookEvent::PostToolUse]);
-        assert_eq!(restored.hook_matcher, Some(serde_json::json!({"tool": "Write"})));
+        assert_eq!(
+            restored.hook_matcher,
+            Some(serde_json::json!({"tool": "Write"}))
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Pull Request

### Short Summary

Adds `ToolCard` — a new registry-tracked card type for versioned AI agent tools. A tool is a YAML-frontmatter markdown file that describes a shell script, MCP server, API call, slash command, or lifecycle hook, and ships with a CLI to push/pull/install it into Claude Code, Gemini CLI, Codex, or GitHub Copilot config. This is the full vertical slice: SQL schema, Rust card struct, CLI (`opsml tool push/pull/list/init`), server endpoints, and marketplace queries.

### Context

Tools are the packaging primitive for anything an AI agent can invoke. The card format is YAML frontmatter + body (same pattern as `SkillCard`), where the frontmatter declares type, config, and metadata, and the body is the implementation (shell script, API template, etc.):

```markdown
---
name: run-linter
toolType: ShellScript
description: Run clippy on the workspace
scriptConfig:
  script: cargo clippy --workspace --all-features -- -D warnings
  shell: /bin/bash
requiresApproval: false
---

#!/bin/bash
cargo clippy --workspace --all-features -- -D warnings
```

Hook tools register into the agent's own config files so the script runs on every tool invocation:

```markdown
---
name: log-tool-use
toolType: Hook
description: Audit log for all Write tool calls
hookEvents:
  - PostToolUse
hookMatcher:
  tool: Write
requiresApproval: false
---

#!/bin/bash
echo "$(date) WRITE $TOOL_INPUT_PATH" >> ~/.opsml/audit.log
```

```bash
# Pull a hook tool and wire it into Claude Code globally
opsml tool pull myteam/log-tool-use --target claudecode --global
```

**`opsml_tool_registry` (SQL)** — New migration across SQLite, Postgres, and MySQL. The table stores `tool_type TEXT` (not an enum column), `args_schema TEXT`, `content_hash BLOB`, and `download_count`. Three indexes: `(space, name)`, `(tool_type)`, and `(download_count DESC)` for marketplace queries.

**`ToolType` / `ToolSpec` / `ToolCard` (types + cards)** — `ToolType` has 7 variants (ShellScript, McpServer, ApiCall, InternalFunction, SlashCommand, Hook, Custom). `ToolSpec` is the YAML-frontmatter struct with type-specific config blocks (`ShellScriptConfig`, `ApiCallConfig`) and hook fields (`hook_events: Vec<HookEvent>`, `hook_matcher: Option<Value>`). `HookEvent` uses PascalCase serde to match Claude Code's settings format natively. `ApiCallConfig` has a `sanitize_for_response()` method that strips sensitive header keys (Authorization, x-api-key, cookie, etc.) before the card is returned over the API.

**`HookInstaller` trait (installer)** — `install_hook(name, script_path, events, matcher, global)` with four impls. Claude Code writes PascalCase event keys into `.claude/settings.json`; Gemini and Codex write snake_case keys into their respective config files; Copilot emits a warning and returns `Ok(())` since it doesn't have a hook system. All four are idempotent on re-install. Hook tests share a process-wide `CWD_LOCK` mutex because the installers use relative paths.

**`pull_artifacts` (ToolCard)** — Dispatches on `ToolType`. `Hook` and `ShellScript` write the body to disk at `{install_dir}/.opsml/hooks/{name}.sh` or `{install_dir}/{name}.sh` and set `0o755`. `SlashCommand` copies to the installer's command dir. `McpServer` merges into `.mcp.json`. `InternalFunction`/`Custom` serialize the spec to YAML.

**CLI (`opsml tool push/pull/list/init`)** — `push` reads a `.md` file, parses YAML frontmatter via `parse_tool_markdown`, registers with the tool registry. `pull` fetches and calls `pull_artifacts`; Hook tools require `--target` (claudecode | geminicli | codex | githubcopilot), optional `--global`. `list` filters by space, name, version, or `--tool-type`. `init --type {shell|slash|mcp|hook|apicall}` scaffolds a typed template.

**Server** — `/v1/tool/{space}/{name}` and `/v1/tool/{space}/{name}/{version}` serve the card as decrypted markdown. `/v1/map/{space}` now includes `tools` (all tool types) and `commands` (SlashCommand only) alongside the existing `skills`/`subagents` keys. Marketplace endpoints (`/v1/marketplace/tools/featured`, `/v1/marketplace/tools/stats`, `/v1/marketplace/tools/tags`) are added on the agentic router.

| File | Change |
|---|---|
| `opsml_types/src/contracts/tool.rs` | ToolType, ToolSpec, HookEvent, ApiCallConfig, ShellScriptConfig |
| `opsml_types/src/contracts/card.rs` | ToolCardClientRecord, ToolCardServerRecord request/response types |
| `opsml_cards/src/tool/card.rs` | ToolCard, parse_tool_markdown, to_markdown, pull_artifacts, save_card |
| `opsml_cards/src/tool/installer.rs` | HookInstaller + SlashCommandInstaller + McpConfigInstaller impls for 4 CLIs |
| `opsml_cards/src/tool/error.rs` | ToolError (thiserror, IO + serde_yaml + serde_json + serde_qs) |
| `opsml_cli/src/actions/tool.rs` | push_tool, pull_tool, list_tools, init_tool + unit tests |
| `opsml_cli/src/cli/arg.rs` | ToolPushArgs, ToolPullArgs, ToolListArgs, ToolInitArgs, PullTarget |
| `opsml_server/src/core/agentic/route.rs` | Tool endpoints + marketplace routes + /v1/map integration |
| `opsml_server/src/core/cards/route.rs` | Tool card CRUD routes wired into the card router |
| `opsml_sql/src/*/helper.rs` | ToolLogicTrait impls (insert, get by name/version, list by space, increment download count) |
| `opsml_sql/src/schemas/schema.rs` | ToolCardRecord, ToolCardServerRecord sqlx structs |
| `opsml_sql/src/*/migrations/20260331000000_tool_registry.sql` | New table + indexes (SQLite, Postgres, MySQL) |
| `opsml_server/tests/api/tool_cli.rs` | Server integration tests: push, list, hook fixture, /v1/map assertions |

### Is this a Breaking Change?

No. The migration adds a new table and doesn't touch existing ones. The `/v1/map/{space}` response gains two new keys (`tools`, `commands`) but existing keys (`skills`, `subagents`) are unchanged, so clients that don't read those keys are unaffected. The new `opsml tool` CLI subcommand is purely additive. `RegistryType::Tool` is a new variant — if you're matching on `RegistryType` exhaustively in downstream code, you'll get a compile error and need to add an arm.