### PR TITLE
357

### DIFF
--- a/crates/opsml_cards/Cargo.toml
+++ b/crates/opsml_cards/Cargo.toml
@@ -31,12 +31,12 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 sysinfo = { workspace = true }
+tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
-tempfile = { workspace = true }
 
 [features]
 default = []

--- a/crates/opsml_cards/src/tool/card.rs
+++ b/crates/opsml_cards/src/tool/card.rs
@@ -270,15 +270,15 @@ impl ToolCard {
         }
 
         // Verify content hash before writing any script to disk.
-        if matches!(self.spec.tool_type, ToolType::ShellScript | ToolType::Hook) {
-            if let Some(expected) = expected_hash {
-                let actual = self.calculate_content_hash()?;
-                if actual != expected {
-                    return Err(ToolError::Error(format!(
-                        "Content hash mismatch for '{}': registry record does not match received body. Refusing to install.",
-                        self.name
-                    )));
-                }
+        if matches!(self.spec.tool_type, ToolType::ShellScript | ToolType::Hook)
+            && let Some(expected) = expected_hash
+        {
+            let actual = self.calculate_content_hash()?;
+            if actual != expected {
+                return Err(ToolError::Error(format!(
+                    "Content hash mismatch for '{}': registry record does not match received body. Refusing to install.",
+                    self.name
+                )));
             }
         }
 

--- a/crates/opsml_cards/src/tool/card.rs
+++ b/crates/opsml_cards/src/tool/card.rs
@@ -3,7 +3,9 @@ use crate::BaseArgs;
 use crate::error::CardError;
 use crate::traits::{OpsmlCard, ProfileExt};
 use chrono::{DateTime, Utc};
-use opsml_types::contracts::tool::{ToolSpec, ToolType};
+use opsml_types::contracts::tool::{
+    ApiCallConfig, HookEvent, ShellScriptConfig, ToolSpec, ToolType,
+};
 use opsml_types::contracts::{CardRecord, ToolCardClientRecord};
 use opsml_types::{RegistryType, SaveName, Suffix};
 use opsml_utils::PyHelperFuncs;
@@ -58,6 +60,33 @@ pub fn parse_tool_markdown(content: &str) -> Result<ToolCard, ToolError> {
     let mut card = ToolCard::new_rs(spec, Some("opsml"), Some(&name), None, None)?;
     card.body = body_opt;
     Ok(card)
+}
+
+/// Validate a shell script body before writing to disk.
+/// Enforces a 1 MB size limit and requires a shebang from the allowlist.
+fn validate_script_body(body: &str, tool_name: &str) -> Result<(), ToolError> {
+    const MAX_BYTES: usize = 1024 * 1024;
+    const ALLOWED_SHEBANGS: &[&str] = &[
+        "#!/bin/sh",
+        "#!/bin/bash",
+        "#!/usr/bin/env bash",
+        "#!/usr/bin/env sh",
+    ];
+    if body.len() > MAX_BYTES {
+        return Err(ToolError::Error(format!(
+            "script body for '{}' exceeds 1 MB limit",
+            tool_name
+        )));
+    }
+    let first_line = body.lines().next().unwrap_or("");
+    if !ALLOWED_SHEBANGS.iter().any(|s| first_line.starts_with(s)) {
+        return Err(ToolError::Error(format!(
+            "script body for '{}' must start with one of: {}",
+            tool_name,
+            ALLOWED_SHEBANGS.join(", ")
+        )));
+    }
+    Ok(())
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -169,16 +198,16 @@ impl ToolCard {
             #[serde(skip_serializing_if = "Option::is_none")]
             output_schema: Option<&'a serde_json::Value>,
             #[serde(skip_serializing_if = "Option::is_none")]
-            script_config: Option<&'a opsml_types::contracts::tool::ShellScriptConfig>,
+            script_config: Option<&'a ShellScriptConfig>,
             #[serde(skip_serializing_if = "Option::is_none")]
-            api_config: Option<&'a opsml_types::contracts::tool::ApiCallConfig>,
+            api_config: Option<&'a ApiCallConfig>,
             #[serde(skip_serializing_if = "Option::is_none")]
             mcp_server_name: Option<&'a str>,
             #[serde(skip_serializing_if = "<[_]>::is_empty")]
             allowed_tools: &'a [String],
             requires_approval: bool,
             #[serde(skip_serializing_if = "<[_]>::is_empty")]
-            hook_events: &'a [opsml_types::contracts::tool::HookEvent],
+            hook_events: &'a [HookEvent],
             #[serde(skip_serializing_if = "Option::is_none")]
             hook_matcher: Option<&'a serde_json::Value>,
         }
@@ -215,6 +244,7 @@ impl ToolCard {
         install_dir: PathBuf,
         hook_installer: Option<&dyn super::installer::HookInstaller>,
         global: bool,
+        expected_hash: Option<&[u8]>,
     ) -> Result<PathBuf, ToolError> {
         if self.name.is_empty()
             || !self
@@ -228,6 +258,7 @@ impl ToolCard {
             )));
         }
         std::fs::create_dir_all(&install_dir)?;
+        #[cfg(unix)]
         let install_dir = install_dir.canonicalize()?;
         if matches!(self.spec.tool_type, ToolType::ShellScript | ToolType::Hook)
             && self.body.is_none()
@@ -237,7 +268,26 @@ impl ToolCard {
                 self.spec.tool_type, self.name
             )));
         }
+
+        // Verify content hash before writing any script to disk.
+        if matches!(self.spec.tool_type, ToolType::ShellScript | ToolType::Hook) {
+            if let Some(expected) = expected_hash {
+                let actual = self.calculate_content_hash()?;
+                if actual != expected {
+                    return Err(ToolError::Error(format!(
+                        "Content hash mismatch for '{}': registry record does not match received body. Refusing to install.",
+                        self.name
+                    )));
+                }
+            }
+        }
+
         let body_content = self.body.as_deref().unwrap_or("");
+
+        // Validate script body content (size + shebang) before writing.
+        if matches!(self.spec.tool_type, ToolType::ShellScript | ToolType::Hook) {
+            validate_script_body(body_content, &self.name)?;
+        }
 
         match &self.spec.tool_type {
             ToolType::ShellScript => {
@@ -299,7 +349,13 @@ impl ToolCard {
                 let relative_path = std::env::current_dir()
                     .ok()
                     .and_then(|cwd| path.strip_prefix(&cwd).ok().map(|p| p.to_path_buf()))
-                    .unwrap_or_else(|| path.clone());
+                    .unwrap_or_else(|| {
+                        tracing::warn!(
+                            "Could not make hook path relative to CWD; registering absolute path: {}",
+                            path.display()
+                        );
+                        path.clone()
+                    });
                 if let Some(installer) = hook_installer {
                     installer.install_hook(
                         &self.name,
@@ -597,7 +653,7 @@ mod tests {
         card.body = Some("#!/bin/bash\necho hello\n".to_string());
 
         let path = card
-            .pull_artifacts(tmp.path().to_path_buf(), None, false)
+            .pull_artifacts(tmp.path().to_path_buf(), None, false, None)
             .unwrap();
         assert!(path.exists());
         assert!(path.to_str().unwrap().ends_with(".sh"));
@@ -614,7 +670,7 @@ mod tests {
         card.body = Some("Run the linter.\n".to_string());
 
         let path = card
-            .pull_artifacts(tmp.path().to_path_buf(), None, false)
+            .pull_artifacts(tmp.path().to_path_buf(), None, false, None)
             .unwrap();
         assert!(path.exists());
         assert!(path.to_str().unwrap().ends_with(".md"));
@@ -631,7 +687,7 @@ mod tests {
         let card = ToolCard::new_rs(spec, Some("test-space"), Some("my-mcp"), None, None).unwrap();
 
         let path = card
-            .pull_artifacts(tmp.path().to_path_buf(), None, false)
+            .pull_artifacts(tmp.path().to_path_buf(), None, false, None)
             .unwrap();
         assert!(path.exists());
         assert!(path.to_str().unwrap().ends_with("-mcp.json"));
@@ -644,7 +700,7 @@ mod tests {
         let card = ToolCard::new_rs(spec, Some("test-space"), Some("my-api"), None, None).unwrap();
 
         let path = card
-            .pull_artifacts(tmp.path().to_path_buf(), None, false)
+            .pull_artifacts(tmp.path().to_path_buf(), None, false, None)
             .unwrap();
         assert!(path.exists());
         assert!(path.to_str().unwrap().ends_with("-api.yaml"));
@@ -713,7 +769,7 @@ mod tests {
         };
         let card = ToolCard::new_rs(spec, Some("s"), Some("my-func"), None, None).unwrap();
         let output = card
-            .pull_artifacts(tmp.path().to_path_buf(), None, false)
+            .pull_artifacts(tmp.path().to_path_buf(), None, false, None)
             .unwrap();
         assert!(output.exists());
         assert!(output.to_string_lossy().ends_with("-spec.yaml"));
@@ -730,7 +786,7 @@ mod tests {
         };
         let card = ToolCard::new_rs(spec, Some("s"), Some("my-custom"), None, None).unwrap();
         let output = card
-            .pull_artifacts(tmp.path().to_path_buf(), None, false)
+            .pull_artifacts(tmp.path().to_path_buf(), None, false, None)
             .unwrap();
         assert!(output.exists());
         assert!(output.to_string_lossy().ends_with("-spec.yaml"));
@@ -768,7 +824,7 @@ mod tests {
         card.body = Some("#!/bin/bash\necho hook\n".to_string());
 
         let path = card
-            .pull_artifacts(tmp.path().to_path_buf(), None, false)
+            .pull_artifacts(tmp.path().to_path_buf(), None, false, None)
             .unwrap();
         assert!(path.exists());
         assert!(path.to_string_lossy().ends_with(".sh"));
@@ -793,7 +849,7 @@ mod tests {
         let mut card = ToolCard::new_rs(spec, Some("s"), Some("no-installer"), None, None).unwrap();
         card.body = Some("#!/bin/bash\necho no-installer\n".to_string());
         let path = card
-            .pull_artifacts(tmp.path().to_path_buf(), None, false)
+            .pull_artifacts(tmp.path().to_path_buf(), None, false, None)
             .unwrap();
         assert!(path.exists());
     }
@@ -832,7 +888,7 @@ mod tests {
             let card = make_hook_card("my-hook");
             let installer = ClaudeCodeInstaller;
             let path = card
-                .pull_artifacts(tmp.to_path_buf(), Some(&installer), false)
+                .pull_artifacts(tmp.to_path_buf(), Some(&installer), false, None)
                 .unwrap();
             assert!(path.exists(), "script must be written");
 
@@ -864,7 +920,12 @@ mod tests {
         let card = make_hook_card("my-hook");
         let installer = ClaudeCodeInstaller;
         let path = card
-            .pull_artifacts(install_tmp.path().to_path_buf(), Some(&installer), false)
+            .pull_artifacts(
+                install_tmp.path().to_path_buf(),
+                Some(&installer),
+                false,
+                None,
+            )
             .unwrap();
         assert!(path.exists(), "script must be written at install_dir");
 
@@ -898,7 +959,7 @@ mod tests {
             let card = make_hook_card("my-hook");
             let installer = GeminiCliInstaller;
             let path = card
-                .pull_artifacts(tmp.to_path_buf(), Some(&installer), false)
+                .pull_artifacts(tmp.to_path_buf(), Some(&installer), false, None)
                 .unwrap();
             assert!(path.exists(), "script must be written");
 
@@ -922,7 +983,7 @@ mod tests {
             let card = make_hook_card("my-hook");
             let installer = CodexInstaller;
             let path = card
-                .pull_artifacts(tmp.to_path_buf(), Some(&installer), false)
+                .pull_artifacts(tmp.to_path_buf(), Some(&installer), false, None)
                 .unwrap();
             assert!(path.exists(), "script must be written");
 
@@ -944,7 +1005,7 @@ mod tests {
             let card = make_hook_card("my-hook");
             let installer = CopilotInstaller;
             let path = card
-                .pull_artifacts(tmp.to_path_buf(), Some(&installer), false)
+                .pull_artifacts(tmp.to_path_buf(), Some(&installer), false, None)
                 .unwrap();
             // Copilot writes the script but no config file
             assert!(path.exists(), "script must be written");
@@ -972,13 +1033,13 @@ mod tests {
             let card = make_hook_card("multi-hook");
 
             // Pull to all four targets in sequence (same working dir = same config dir)
-            card.pull_artifacts(tmp.to_path_buf(), Some(&ClaudeCodeInstaller), false)
+            card.pull_artifacts(tmp.to_path_buf(), Some(&ClaudeCodeInstaller), false, None)
                 .unwrap();
-            card.pull_artifacts(tmp.to_path_buf(), Some(&GeminiCliInstaller), false)
+            card.pull_artifacts(tmp.to_path_buf(), Some(&GeminiCliInstaller), false, None)
                 .unwrap();
-            card.pull_artifacts(tmp.to_path_buf(), Some(&CodexInstaller), false)
+            card.pull_artifacts(tmp.to_path_buf(), Some(&CodexInstaller), false, None)
                 .unwrap();
-            card.pull_artifacts(tmp.to_path_buf(), Some(&CopilotInstaller), false)
+            card.pull_artifacts(tmp.to_path_buf(), Some(&CopilotInstaller), false, None)
                 .unwrap();
 
             // Script written once (subsequent pulls overwrite same path — that's fine)
@@ -1024,9 +1085,9 @@ mod tests {
             let card = make_hook_card("cross-hook");
 
             // Register in Codex first, then Claude — both configs must be independent
-            card.pull_artifacts(tmp.to_path_buf(), Some(&CodexInstaller), false)
+            card.pull_artifacts(tmp.to_path_buf(), Some(&CodexInstaller), false, None)
                 .unwrap();
-            card.pull_artifacts(tmp.to_path_buf(), Some(&ClaudeCodeInstaller), false)
+            card.pull_artifacts(tmp.to_path_buf(), Some(&ClaudeCodeInstaller), false, None)
                 .unwrap();
 
             let codex: serde_json::Value = serde_yaml::from_str(
@@ -1049,9 +1110,9 @@ mod tests {
         with_hook_tempdir(|tmp| {
             let card = make_hook_card("cross-hook2");
 
-            card.pull_artifacts(tmp.to_path_buf(), Some(&ClaudeCodeInstaller), false)
+            card.pull_artifacts(tmp.to_path_buf(), Some(&ClaudeCodeInstaller), false, None)
                 .unwrap();
-            card.pull_artifacts(tmp.to_path_buf(), Some(&GeminiCliInstaller), false)
+            card.pull_artifacts(tmp.to_path_buf(), Some(&GeminiCliInstaller), false, None)
                 .unwrap();
 
             let claude: serde_json::Value = serde_json::from_str(
@@ -1170,7 +1231,7 @@ mod tests {
         };
         let card = ToolCard::new_rs(spec, Some("test"), Some("no-body"), None, None).unwrap();
         let tmp = tempfile::tempdir().unwrap();
-        let result = card.pull_artifacts(tmp.path().to_path_buf(), None, false);
+        let result = card.pull_artifacts(tmp.path().to_path_buf(), None, false, None);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("no body"));
     }
@@ -1186,7 +1247,7 @@ mod tests {
         };
         let card = ToolCard::new_rs(spec, Some("test"), Some("no-body-hook"), None, None).unwrap();
         let tmp = tempfile::tempdir().unwrap();
-        let result = card.pull_artifacts(tmp.path().to_path_buf(), None, false);
+        let result = card.pull_artifacts(tmp.path().to_path_buf(), None, false, None);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("no body"));
     }
@@ -1255,5 +1316,77 @@ mod tests {
             Some(serde_json::json!({"tool": "Write"}))
         );
         assert_eq!(hash_before, hash_after);
+    }
+
+    #[test]
+    fn test_parse_tool_markdown_invalid_hook_matcher_is_err() {
+        let md = "---\nname: bad-hook\ndescription: test\ntoolType: Hook\nhookEvents:\n  - PostToolUse\nhookMatcher: 42\n---\n#!/bin/bash\n";
+        let result = parse_tool_markdown(md);
+        assert!(result.is_err(), "expected parse error for hookMatcher: 42");
+    }
+
+    #[test]
+    fn test_pull_artifacts_hash_mismatch_returns_error() {
+        let spec = ToolSpec {
+            name: "tampered".to_string(),
+            description: "test".to_string(),
+            tool_type: ToolType::Hook,
+            hook_events: vec![HookEvent::PostToolUse],
+            ..Default::default()
+        };
+        let mut card = ToolCard::new_rs(spec, Some("s"), Some("tampered"), None, None).unwrap();
+        card.body = Some("#!/bin/bash\necho legit\n".to_string());
+
+        let wrong_hash = vec![0u8; 32]; // deliberately wrong 32-byte hash
+        let tmp = tempfile::tempdir().unwrap();
+        let result = card.pull_artifacts(tmp.path().to_path_buf(), None, false, Some(&wrong_hash));
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("hash mismatch") || msg.contains("Content hash"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_validate_script_body_size_limit() {
+        let spec = ToolSpec {
+            name: "big-script".to_string(),
+            description: "test".to_string(),
+            tool_type: ToolType::ShellScript,
+            ..Default::default()
+        };
+        let mut card = ToolCard::new_rs(spec, Some("s"), Some("big-script"), None, None).unwrap();
+        // Body just over 1 MB — must fail validation
+        let body = format!("#!/bin/bash\n{}", "x".repeat(1024 * 1024));
+        card.body = Some(body);
+        let tmp = tempfile::tempdir().unwrap();
+        let result = card.pull_artifacts(tmp.path().to_path_buf(), None, false, None);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("1 MB") || msg.contains("exceeds"),
+            "unexpected: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_validate_script_body_missing_shebang_is_err() {
+        let spec = ToolSpec {
+            name: "no-shebang".to_string(),
+            description: "test".to_string(),
+            tool_type: ToolType::ShellScript,
+            ..Default::default()
+        };
+        let mut card = ToolCard::new_rs(spec, Some("s"), Some("no-shebang"), None, None).unwrap();
+        card.body = Some("echo hello\n".to_string());
+        let tmp = tempfile::tempdir().unwrap();
+        let result = card.pull_artifacts(tmp.path().to_path_buf(), None, false, None);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("shebang") || msg.contains("#!"),
+            "unexpected: {msg}"
+        );
     }
 }

--- a/crates/opsml_cards/src/tool/installer.rs
+++ b/crates/opsml_cards/src/tool/installer.rs
@@ -1,8 +1,20 @@
 use super::error::ToolError;
 use opsml_types::contracts::tool::HookEvent;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use tracing::warn;
+
+/// Typed representation of `.codex/config.yaml` that preserves unknown fields on round-trip.
+/// Using a typed struct instead of `serde_json::Value` prevents block-scalar corruption.
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct CodexConfig {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    hooks: Vec<Value>,
+    #[serde(flatten)]
+    other: HashMap<String, Value>,
+}
 
 pub trait SlashCommandInstaller {
     fn command_dir(&self) -> PathBuf;
@@ -76,15 +88,17 @@ fn read_json_or_default(path: &Path) -> Value {
 }
 
 fn write_json(path: &Path, value: &Value) -> Result<(), ToolError> {
-    if let Some(parent) = path.parent()
-        && !parent.as_os_str().is_empty()
-    {
+    let parent = path.parent().unwrap_or_else(|| std::path::Path::new("."));
+    if !parent.as_os_str().is_empty() {
         std::fs::create_dir_all(parent)?;
     }
     let content = serde_json::to_string_pretty(value)?;
-    let tmp_path = path.with_extension("json.tmp");
-    std::fs::write(&tmp_path, &content)?;
-    std::fs::rename(&tmp_path, path)?;
+    let mut tmp = tempfile::NamedTempFile::new_in(parent)
+        .map_err(|e| ToolError::Error(format!("Failed to create temp file: {e}")))?;
+    use std::io::Write;
+    tmp.write_all(content.as_bytes())?;
+    tmp.persist(path)
+        .map_err(|e| ToolError::Error(format!("Failed to persist {}: {e}", path.display())))?;
     Ok(())
 }
 
@@ -125,6 +139,24 @@ fn script_exists_in_arr(arr: &Value, script_path: &Path) -> bool {
         .unwrap_or(false)
 }
 
+fn validate_tool_string(s: &str) -> Result<(), ToolError> {
+    const MAX_LEN: usize = 128;
+    if s.len() > MAX_LEN {
+        return Err(ToolError::Error(format!(
+            "hook_matcher tool value exceeds {MAX_LEN} characters"
+        )));
+    }
+    if !s
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == ':')
+    {
+        return Err(ToolError::Error(format!(
+            "hook_matcher tool value '{s}' must contain only [a-zA-Z0-9_-:]"
+        )));
+    }
+    Ok(())
+}
+
 pub(crate) fn validate_hook_matcher(v: &serde_json::Value) -> Result<(), ToolError> {
     match v {
         serde_json::Value::Null | serde_json::Value::String(_) => Ok(()),
@@ -133,8 +165,13 @@ pub(crate) fn validate_hook_matcher(v: &serde_json::Value) -> Result<(), ToolErr
                 && let Some(tool_val) = map.get("tool")
             {
                 match tool_val {
-                    serde_json::Value::String(_) => return Ok(()),
+                    serde_json::Value::String(s) => return validate_tool_string(s),
                     serde_json::Value::Array(arr) if arr.iter().all(|v| v.is_string()) => {
+                        for s in arr {
+                            if let serde_json::Value::String(s) = s {
+                                validate_tool_string(s)?;
+                            }
+                        }
                         return Ok(());
                     }
                     _ => {}
@@ -149,6 +186,18 @@ pub(crate) fn validate_hook_matcher(v: &serde_json::Value) -> Result<(), ToolErr
                 .to_string(),
         )),
     }
+}
+
+fn validate_hook_args(events: &[HookEvent], matcher: Option<&Value>) -> Result<(), ToolError> {
+    if events.is_empty() {
+        return Err(ToolError::Error(
+            "Hook tool has no hook_events configured; nothing to register".to_string(),
+        ));
+    }
+    if let Some(m) = matcher {
+        validate_hook_matcher(m)?;
+    }
+    Ok(())
 }
 
 pub trait HookInstaller {
@@ -197,14 +246,7 @@ impl HookInstaller for ClaudeCodeInstaller {
         matcher: Option<&Value>,
         global: bool,
     ) -> Result<(), ToolError> {
-        if events.is_empty() {
-            return Err(ToolError::Error(
-                "Hook tool has no hook_events configured; nothing to register".to_string(),
-            ));
-        }
-        if let Some(m) = matcher {
-            validate_hook_matcher(m)?;
-        }
+        validate_hook_args(events, matcher)?;
         let settings_path = if global {
             dirs::home_dir()
                 .ok_or_else(|| ToolError::Error("Could not determine home directory".to_string()))?
@@ -284,14 +326,7 @@ impl HookInstaller for GeminiCliInstaller {
         matcher: Option<&Value>,
         global: bool,
     ) -> Result<(), ToolError> {
-        if events.is_empty() {
-            return Err(ToolError::Error(
-                "Hook tool has no hook_events configured; nothing to register".to_string(),
-            ));
-        }
-        if let Some(m) = matcher {
-            validate_hook_matcher(m)?;
-        }
+        validate_hook_args(events, matcher)?;
         let settings_path = if global {
             dirs::home_dir()
                 .ok_or_else(|| ToolError::Error("Could not determine home directory".to_string()))?
@@ -367,14 +402,7 @@ impl HookInstaller for CodexInstaller {
         matcher: Option<&Value>,
         global: bool,
     ) -> Result<(), ToolError> {
-        if events.is_empty() {
-            return Err(ToolError::Error(
-                "Hook tool has no hook_events configured; nothing to register".to_string(),
-            ));
-        }
-        if let Some(m) = matcher {
-            validate_hook_matcher(m)?;
-        }
+        validate_hook_args(events, matcher)?;
         let config_path = if global {
             dirs::home_dir()
                 .ok_or_else(|| ToolError::Error("Could not determine home directory".to_string()))?
@@ -383,27 +411,18 @@ impl HookInstaller for CodexInstaller {
             PathBuf::from(".codex/config.yaml")
         };
 
-        let mut config: Value = if config_path.exists() {
+        let mut config: CodexConfig = if config_path.exists() {
             let content = std::fs::read_to_string(&config_path)?;
             serde_yaml::from_str(&content)?
         } else {
-            Value::Object(serde_json::Map::new())
+            CodexConfig::default()
         };
-
-        let hooks_arr = config
-            .as_object_mut()
-            .ok_or_else(|| ToolError::Error("config.yaml root is not an object".to_string()))?
-            .entry("hooks")
-            .or_insert_with(|| Value::Array(vec![]));
-        let hooks_arr = hooks_arr
-            .as_array_mut()
-            .ok_or_else(|| ToolError::Error("hooks is not an array".to_string()))?;
 
         let script_str = script_path.to_string_lossy().to_string();
 
         for event in events {
             let event_name = event.as_snake_case();
-            let already_exists = hooks_arr.iter().any(|e| {
+            let already_exists = config.hooks.iter().any(|e| {
                 e.get("script")
                     .and_then(|s| s.as_str())
                     .map(|s| s == script_str)
@@ -424,7 +443,7 @@ impl HookInstaller for CodexInstaller {
                         .ok_or_else(|| ToolError::Error("hook entry is not an object".to_string()))?
                         .insert("filter".to_string(), m.clone());
                 }
-                hooks_arr.push(entry);
+                config.hooks.push(entry);
             }
         }
 
@@ -434,9 +453,15 @@ impl HookInstaller for CodexInstaller {
             std::fs::create_dir_all(parent)?;
         }
         let yaml_content = serde_yaml::to_string(&config)?;
-        let tmp_path = config_path.with_extension("yaml.tmp");
-        std::fs::write(&tmp_path, &yaml_content)?;
-        std::fs::rename(&tmp_path, &config_path)?;
+        let parent = config_path
+            .parent()
+            .unwrap_or_else(|| std::path::Path::new("."));
+        let mut tmp = tempfile::NamedTempFile::new_in(parent)
+            .map_err(|e| ToolError::Error(format!("Failed to create temp file: {e}")))?;
+        use std::io::Write;
+        tmp.write_all(yaml_content.as_bytes())?;
+        tmp.persist(&config_path)
+            .map_err(|e| ToolError::Error(format!("Failed to persist config.yaml: {e}")))?;
         Ok(())
     }
 }
@@ -754,6 +779,36 @@ mod tests {
         let result = installer.install_hook("my-hook", &script_path, &[], None, false);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("hook_events"));
+    }
+
+    #[test]
+    fn test_validate_hook_matcher_non_string_tool_value_is_err() {
+        let bad = serde_json::json!({"tool": 42});
+        assert!(validate_hook_matcher(&bad).is_err());
+    }
+
+    #[test]
+    fn test_validate_hook_matcher_non_object_top_level_is_err() {
+        let bad = serde_json::json!(42);
+        assert!(validate_hook_matcher(&bad).is_err());
+    }
+
+    #[test]
+    fn test_validate_tool_string_too_long_is_err() {
+        let long = "a".repeat(129);
+        assert!(validate_tool_string(&long).is_err());
+    }
+
+    #[test]
+    fn test_validate_tool_string_invalid_chars_is_err() {
+        assert!(validate_tool_string("foo bar").is_err());
+        assert!(validate_tool_string("foo;bar").is_err());
+    }
+
+    #[test]
+    fn test_validate_tool_string_valid_passes() {
+        assert!(validate_tool_string("Write").is_ok());
+        assert!(validate_tool_string("my-tool_123:action").is_ok());
     }
 
     #[test]

--- a/crates/opsml_cards/src/tool/mod.rs
+++ b/crates/opsml_cards/src/tool/mod.rs
@@ -18,8 +18,12 @@ pub(crate) mod test_util {
 
     pub(crate) fn with_tempdir<F: FnOnce(&Path)>(f: F) {
         let _guard = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let orig = std::env::current_dir().ok();
         let tmp = tempfile::tempdir().expect("tempdir");
         std::env::set_current_dir(tmp.path()).expect("set_current_dir");
         f(tmp.path());
+        if let Some(orig) = orig {
+            let _ = std::env::set_current_dir(orig);
+        }
     }
 }

--- a/crates/opsml_cli/src/actions/lock.rs
+++ b/crates/opsml_cli/src/actions/lock.rs
@@ -10,10 +10,11 @@ use opsml_registry::{CardRegistries, CardRegistry};
 use opsml_service::{OpsmlServiceSpec, service::DEFAULT_SERVICE_FILENAME};
 use opsml_toml::{LockArtifact, LockFile};
 use opsml_types::IntegratedService;
-use opsml_types::contracts::CardVariant;
+use opsml_types::contracts::{CardVariant, ServiceType};
 use opsml_types::{RegistryType, contracts::CardRecord};
 use pyo3::prelude::*;
 use scouter_client::{DriftType, ProfileStatusRequest};
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::vec;
@@ -103,6 +104,52 @@ pub(crate) fn create_lock_artifact_from_service_card(
         registry_type: service_card.registry_type.clone(),
         write_dir: write_dir.to_string(),
     }
+}
+
+/// Resolve all CardRefs from workflow steps into LockArtifacts.
+/// Each step's skill/agent/mcp ref is resolved against its respective registry.
+/// Returns an empty Vec if the spec has no workflow config.
+fn resolve_workflow_refs(
+    spec: &OpsmlServiceSpec,
+    registries: &CardRegistries,
+) -> Result<Vec<LockArtifact>, CliError> {
+    let workflow = spec
+        .service
+        .as_ref()
+        .and_then(|s| s.workflow.as_ref());
+
+    let Some(workflow) = workflow else {
+        return Ok(Vec::new());
+    };
+
+    let mut artifacts = Vec::new();
+    let mut seen: HashSet<(String, String)> = HashSet::new();
+
+    for (card_ref, registry_type) in workflow.card_refs() {
+        let key = (card_ref.space.clone(), card_ref.name.clone());
+        if !seen.insert(key) {
+            continue;
+        }
+
+        let registry = registries.get_registry(&registry_type);
+        if let Some(record) = get_service_from_registry(
+            registry,
+            &card_ref.space,
+            &card_ref.name,
+            card_ref.version.as_ref(),
+        )? {
+            artifacts.push(LockArtifact {
+                space: record.space().to_string(),
+                name: record.name().to_string(),
+                version: record.version().to_string(),
+                uid: record.uid().to_string(),
+                registry_type,
+                write_dir: format!("opsml_workflow/{}", card_ref.name),
+            });
+        }
+    }
+
+    Ok(artifacts)
 }
 
 /// Gets the write directory with a fallback default
@@ -241,7 +288,12 @@ fn download_service_artifacts(
 ) -> Result<(), CliError> {
     for artifact in lockfile.artifact {
         match artifact.registry_type {
-            RegistryType::Service | RegistryType::Mcp | RegistryType::Agent => {
+            RegistryType::Service
+            | RegistryType::Mcp
+            | RegistryType::Agent
+            | RegistryType::Skill
+            | RegistryType::SubAgent
+            | RegistryType::Tool => {
                 println!(
                     "Downloading ServiceCard {}, type: {} to path {}",
                     Colorize::green(&format!(
@@ -389,18 +441,27 @@ pub fn install_service_locally(path: PathBuf, write_path: Option<PathBuf>) -> Re
 #[pyfunction]
 pub fn lock_service(path: PathBuf) -> Result<(), CliError> {
     debug!("Locking service with path: {:?}", path);
-    // handle case of no cards
     let mut spec = OpsmlServiceSpec::from_path(&path).inspect_err(|e| {
         error!("Failed to read service spec: {:?}", e);
     })?;
 
-    // Create a lock file
-    let lock_file = LockFile {
-        artifact: vec![lock_service_card(&mut spec).inspect_err(|e| {
-            error!("Failed to lock service card: {:?}", e);
-        })?],
-    };
-    // TODO
+    let service_artifact = lock_service_card(&mut spec).inspect_err(|e| {
+        error!("Failed to lock service card: {:?}", e);
+    })?;
+
+    let mut artifacts = vec![service_artifact];
+
+    // For workflow services, also resolve step CardRefs into lock artifacts
+    if spec.service_type == ServiceType::Workflow {
+        let registries = CardRegistries::new()?;
+        let mut workflow_artifacts =
+            resolve_workflow_refs(&spec, &registries).inspect_err(|e| {
+                error!("Failed to resolve workflow card refs: {:?}", e);
+            })?;
+        artifacts.append(&mut workflow_artifacts);
+    }
+
+    let lock_file = LockFile { artifact: artifacts };
     lock_file.write(&spec.root_path)?;
 
     Ok(())

--- a/crates/opsml_cli/src/actions/lock.rs
+++ b/crates/opsml_cli/src/actions/lock.rs
@@ -113,20 +113,21 @@ fn resolve_workflow_refs(
     spec: &OpsmlServiceSpec,
     registries: &CardRegistries,
 ) -> Result<Vec<LockArtifact>, CliError> {
-    let workflow = spec
-        .service
-        .as_ref()
-        .and_then(|s| s.workflow.as_ref());
+    let workflow = spec.service.as_ref().and_then(|s| s.workflow.as_ref());
 
     let Some(workflow) = workflow else {
         return Ok(Vec::new());
     };
 
     let mut artifacts = Vec::new();
-    let mut seen: HashSet<(String, String)> = HashSet::new();
+    let mut seen: HashSet<(String, String, String)> = HashSet::new();
 
     for (card_ref, registry_type) in workflow.card_refs() {
-        let key = (card_ref.space.clone(), card_ref.name.clone());
+        let key = (
+            card_ref.space.clone(),
+            card_ref.name.clone(),
+            format!("{registry_type:?}"),
+        );
         if !seen.insert(key) {
             continue;
         }
@@ -461,7 +462,9 @@ pub fn lock_service(path: PathBuf) -> Result<(), CliError> {
         artifacts.append(&mut workflow_artifacts);
     }
 
-    let lock_file = LockFile { artifact: artifacts };
+    let lock_file = LockFile {
+        artifact: artifacts,
+    };
     lock_file.write(&spec.root_path)?;
 
     Ok(())

--- a/crates/opsml_cli/src/actions/tool.rs
+++ b/crates/opsml_cli/src/actions/tool.rs
@@ -4,9 +4,10 @@ use crate::error::CliError;
 use opsml_cards::parse_tool_markdown;
 use opsml_colors::Colorize;
 use opsml_registry::download::download_card_from_registry;
+use opsml_registry::registries::card::OpsmlCardRegistry;
 use opsml_registry::registry::CardRegistry;
 use opsml_types::RegistryType;
-use opsml_types::contracts::{CardList, CardQueryArgs};
+use opsml_types::contracts::{CardList, CardQueryArgs, CardRecord};
 use opsml_utils::clean_string;
 use std::path::PathBuf;
 use tracing::instrument;
@@ -86,6 +87,22 @@ pub fn pull_tool(args: &ToolPullArgs) -> Result<(), CliError> {
         .map_err(|e| CliError::Error(format!("Failed to create temp dir: {e}")))?;
     let tmp_path = tmp_dir.path().to_path_buf();
 
+    // Fetch the stored content hash from the registry before downloading the artifact.
+    // For Hook and ShellScript tools, pull_artifacts will recompute the hash from the
+    // received body and compare against this value — rejecting any tampered content.
+    let registry =
+        OpsmlCardRegistry::new(RegistryType::Tool).map_err(|e| CliError::Error(e.to_string()))?;
+    let records = registry
+        .list_cards(&query_args)
+        .map_err(|e| CliError::Error(e.to_string()))?;
+    let expected_hash: Option<Vec<u8>> = records.into_iter().find_map(|r| {
+        if let CardRecord::Tool(t) = r {
+            t.content_hash
+        } else {
+            None
+        }
+    });
+
     download_card_from_registry(&query_args, tmp_path.clone())?;
 
     let card_json = find_card_json(&tmp_path, 0)?;
@@ -103,7 +120,12 @@ pub fn pull_tool(args: &ToolPullArgs) -> Result<(), CliError> {
     }
     let hook_installer = args.target.as_ref().map(|t| t.as_hook_installer());
     let installed_path = card
-        .pull_artifacts(output_dir, hook_installer.as_deref(), args.global)
+        .pull_artifacts(
+            output_dir,
+            hook_installer.as_deref(),
+            args.global,
+            expected_hash.as_deref(),
+        )
         .map_err(|e| CliError::Error(e.to_string()))?;
 
     println!(

--- a/crates/opsml_types/src/cards/types.rs
+++ b/crates/opsml_types/src/cards/types.rs
@@ -98,6 +98,7 @@ impl CardTable {
             ServiceType::Mcp => CardTable::Mcp,
             ServiceType::Api => CardTable::Service,
             ServiceType::Agent => CardTable::Agent,
+            ServiceType::Workflow => CardTable::Service,
         }
     }
 }

--- a/crates/opsml_types/src/contracts/mod.rs
+++ b/crates/opsml_types/src/contracts/mod.rs
@@ -15,6 +15,7 @@ pub mod skill;
 pub mod subagent;
 pub mod tool;
 pub mod traits;
+pub mod workflow;
 
 pub use agent::*;
 pub use agent_invoke::*;
@@ -32,3 +33,4 @@ pub use skill::*;
 pub use subagent::*;
 pub use tool::*;
 pub use traits::*;
+pub use workflow::*;

--- a/crates/opsml_types/src/contracts/service.rs
+++ b/crates/opsml_types/src/contracts/service.rs
@@ -697,3 +697,92 @@ impl ServiceConfig {
         Ok(None)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::contracts::workflow::{CardRef, WorkflowStep};
+
+    fn skill_step(name: &str) -> WorkflowStep {
+        WorkflowStep {
+            name: name.into(),
+            skill: Some(CardRef {
+                space: "platform".into(),
+                name: "my-skill".into(),
+                version: None,
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_service_config_workflow_missing_config_returns_err() {
+        let mut config = ServiceConfig::default();
+        let err = config
+            .validate(
+                std::path::Path::new("."),
+                "test",
+                &ServiceType::Workflow,
+                &None,
+            )
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("workflow") || err.to_string().contains("Workflow"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_service_config_workflow_invalid_dag_propagates_err() {
+        // Cycle: s1 → s2 → s1
+        let mut s1 = skill_step("s1");
+        s1.depends_on = vec!["s2".into()];
+        let mut s2 = skill_step("s2");
+        s2.depends_on = vec!["s1".into()];
+
+        let mut config = ServiceConfig {
+            workflow: Some(WorkflowSpec {
+                steps: vec![s1, s2],
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let err = config
+            .validate(
+                std::path::Path::new("."),
+                "test",
+                &ServiceType::Workflow,
+                &None,
+            )
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("cycle"),
+            "expected cycle error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_service_config_workflow_valid_linear_dag_is_ok() {
+        let s1 = skill_step("s1");
+        let mut s2 = skill_step("s2");
+        s2.depends_on = vec!["s1".into()];
+
+        let mut config = ServiceConfig {
+            workflow: Some(WorkflowSpec {
+                steps: vec![s1, s2],
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert!(
+            config
+                .validate(
+                    std::path::Path::new("."),
+                    "test",
+                    &ServiceType::Workflow,
+                    &None,
+                )
+                .is_ok()
+        );
+    }
+}

--- a/crates/opsml_types/src/contracts/service.rs
+++ b/crates/opsml_types/src/contracts/service.rs
@@ -2,6 +2,7 @@ use crate::RegistryType;
 use crate::contracts::AgentSpec;
 use crate::contracts::mcp::McpConfig;
 use crate::contracts::potato::PotatoAgentConfig;
+use crate::contracts::workflow::WorkflowSpec;
 use crate::error::{AgentConfigError, TypeError};
 use opsml_semver::VersionType;
 use opsml_utils::extract_py_attr;
@@ -24,6 +25,8 @@ pub enum ServiceType {
     Mcp,
     #[serde(alias = "AGENT", alias = "agent")]
     Agent,
+    #[serde(alias = "WORKFLOW", alias = "workflow")]
+    Workflow,
 }
 
 impl Display for ServiceType {
@@ -32,6 +35,7 @@ impl Display for ServiceType {
             ServiceType::Api => write!(f, "Api"),
             ServiceType::Mcp => write!(f, "Mcp"),
             ServiceType::Agent => write!(f, "Agent"),
+            ServiceType::Workflow => write!(f, "Workflow"),
         }
     }
 }
@@ -41,6 +45,7 @@ impl From<String> for ServiceType {
             "api" => ServiceType::Api,
             "mcp" => ServiceType::Mcp,
             "agent" => ServiceType::Agent,
+            "workflow" => ServiceType::Workflow,
             _ => ServiceType::Api, // default to Api if unknown
         }
     }
@@ -51,6 +56,7 @@ impl From<&str> for ServiceType {
             "api" => ServiceType::Api,
             "mcp" => ServiceType::Mcp,
             "agent" => ServiceType::Agent,
+            "workflow" => ServiceType::Workflow,
             _ => ServiceType::Api, // default to Api if unknown
         }
     }
@@ -573,6 +579,8 @@ pub struct ServiceConfig {
     pub agent: Option<AgentConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub potato: Option<PotatoAgentConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workflow: Option<WorkflowSpec>,
 }
 
 impl ServiceConfig {
@@ -606,6 +614,18 @@ impl ServiceConfig {
             // 1. Agent Skills (if provided)
             agent_config.validate(root_path, deployment_config)?;
         }
+
+        // Workflow services must have a workflow config, and it must be a valid DAG
+        if service_type == &ServiceType::Workflow {
+            if let Some(wf) = &self.workflow {
+                wf.validate()?;
+            } else {
+                return Err(TypeError::WorkflowValidation(
+                    "Workflow service type requires 'workflow' configuration".into(),
+                ));
+            }
+        }
+
         Ok(())
     }
 
@@ -657,6 +677,7 @@ impl ServiceConfig {
             mcp,
             agent: agent_config,
             potato: None,
+            workflow: None,
         })
     }
 

--- a/crates/opsml_types/src/contracts/tool.rs
+++ b/crates/opsml_types/src/contracts/tool.rs
@@ -100,6 +100,11 @@ impl ApiCallConfig {
             "cookie",
             "x-secret",
             "proxy-authorization",
+            "x-amz-security-token",
+            "x-goog-api-key",
+            "x-functions-key",
+            "apikey",
+            "token",
         ];
         let headers = self
             .headers
@@ -107,11 +112,17 @@ impl ApiCallConfig {
             .filter(|(k, _)| !SENSITIVE_KEYS.contains(&k.to_lowercase().as_str()))
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect();
+        // Strip query string — credential-bearing params must never be returned to callers.
+        let url = self
+            .url
+            .split_once('?')
+            .map(|(base, _)| base.to_string())
+            .unwrap_or_else(|| self.url.clone());
         Self {
-            url: self.url.clone(),
+            url,
             method: self.method.clone(),
             headers,
-            body_template: self.body_template.clone(),
+            body_template: None,
         }
     }
 }

--- a/crates/opsml_types/src/contracts/workflow.rs
+++ b/crates/opsml_types/src/contracts/workflow.rs
@@ -1,0 +1,476 @@
+use crate::RegistryType;
+use crate::contracts::ToolSpec;
+use crate::error::TypeError;
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet, VecDeque};
+
+/// Reference to a registered card by space/name/optional version.
+/// Used in WorkflowStep to reference skills, agents, and MCP servers.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+#[serde(default, rename_all = "camelCase")]
+pub struct CardRef {
+    pub space: String,
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+}
+
+/// Canvas position for the future no-code workflow builder UI.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+#[serde(default, rename_all = "camelCase")]
+pub struct Position {
+    pub x: f64,
+    pub y: f64,
+}
+
+/// Optional display metadata attached to a step for a future drag-and-drop composer.
+/// No UI in this PR — stored as part of WorkflowSpec for forward compatibility.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+#[serde(default, rename_all = "camelCase")]
+pub struct StepDisplay {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub position: Option<Position>,
+}
+
+/// A typed workflow input declaration (maps to `inputs:` section of opsmlspec.yaml).
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+#[serde(default, rename_all = "camelCase")]
+pub struct WorkflowInput {
+    /// Input type: "string", "number", "boolean", "json"
+    #[serde(rename = "type")]
+    pub input_type: String,
+    #[serde(default)]
+    pub required: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+/// A single step in a workflow DAG. Exactly one action field
+/// (skill, agent, mcp, tool, or prompt) must be set.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(default, rename_all = "camelCase")]
+pub struct WorkflowStep {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub depends_on: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub skill: Option<CardRef>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent: Option<CardRef>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mcp: Option<CardRef>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool: Option<ToolSpec>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt: Option<String>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub inputs: HashMap<String, String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub outputs: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub condition: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timeout_seconds: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display: Option<StepDisplay>,
+}
+
+impl WorkflowStep {
+    fn has_action(&self) -> bool {
+        self.skill.is_some()
+            || self.agent.is_some()
+            || self.mcp.is_some()
+            || self.tool.is_some()
+            || self.prompt.is_some()
+    }
+}
+
+/// A DAG-based workflow definition. Steps are executed in dependency order.
+/// Registered as a ServiceCard with ServiceType::Workflow — no separate registry table.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(default, rename_all = "camelCase")]
+pub struct WorkflowSpec {
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub inputs: HashMap<String, WorkflowInput>,
+    pub steps: Vec<WorkflowStep>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub outputs: HashMap<String, String>,
+}
+
+impl WorkflowSpec {
+    /// Validate the workflow:
+    /// - no duplicate step names
+    /// - all depends_on targets reference existing steps
+    /// - every step has at least one action (skill/agent/mcp/tool/prompt)
+    /// - the DAG is acyclic (Kahn's algorithm)
+    pub fn validate(&self) -> Result<(), TypeError> {
+        let mut seen_names: HashSet<&str> = HashSet::new();
+
+        for step in &self.steps {
+            if step.name.is_empty() {
+                return Err(TypeError::WorkflowValidation(
+                    "step name must not be empty".into(),
+                ));
+            }
+            if !seen_names.insert(step.name.as_str()) {
+                return Err(TypeError::WorkflowValidation(format!(
+                    "duplicate step name: '{}'",
+                    step.name
+                )));
+            }
+            if !step.has_action() {
+                return Err(TypeError::WorkflowValidation(format!(
+                    "step '{}' has no action (skill, agent, mcp, tool, or prompt required)",
+                    step.name
+                )));
+            }
+        }
+
+        let step_names: HashSet<&str> = self.steps.iter().map(|s| s.name.as_str()).collect();
+
+        for step in &self.steps {
+            for dep in &step.depends_on {
+                if !step_names.contains(dep.as_str()) {
+                    return Err(TypeError::WorkflowValidation(format!(
+                        "step '{}' depends_on unknown step '{}'",
+                        step.name, dep
+                    )));
+                }
+            }
+        }
+
+        // Kahn's algorithm for cycle detection
+        let mut in_degree: HashMap<&str, usize> = self
+            .steps
+            .iter()
+            .map(|s| (s.name.as_str(), 0))
+            .collect();
+
+        for step in &self.steps {
+            for dep in &step.depends_on {
+                *in_degree.entry(step.name.as_str()).or_insert(0) += 1;
+                let _ = dep; // dep drives step's in-degree; we already counted above
+            }
+        }
+
+        // Re-compute cleanly: in_degree[step] = number of steps that step depends on
+        let mut in_degree: HashMap<&str, usize> =
+            self.steps.iter().map(|s| (s.name.as_str(), s.depends_on.len())).collect();
+
+        // Build reverse adjacency: for each dep, which steps depend on it
+        let mut dependents: HashMap<&str, Vec<&str>> = self
+            .steps
+            .iter()
+            .map(|s| (s.name.as_str(), Vec::new()))
+            .collect();
+
+        for step in &self.steps {
+            for dep in &step.depends_on {
+                dependents.entry(dep.as_str()).or_default().push(step.name.as_str());
+            }
+        }
+
+        let mut queue: VecDeque<&str> = in_degree
+            .iter()
+            .filter(|(_, deg)| **deg == 0)
+            .map(|(name, _)| *name)
+            .collect();
+
+        let mut processed = 0usize;
+        while let Some(node) = queue.pop_front() {
+            processed += 1;
+            for &dependent in dependents.get(node).map(|v| v.as_slice()).unwrap_or(&[]) {
+                let deg = in_degree.entry(dependent).or_insert(0);
+                *deg = deg.saturating_sub(1);
+                if *deg == 0 {
+                    queue.push_back(dependent);
+                }
+            }
+        }
+
+        if processed != self.steps.len() {
+            return Err(TypeError::WorkflowValidation(
+                "workflow contains a dependency cycle".into(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    /// Collect all CardRefs from steps along with their expected registry type.
+    /// skill → RegistryType::Skill, agent → RegistryType::Agent, mcp → RegistryType::Mcp
+    pub fn card_refs(&self) -> Vec<(&CardRef, RegistryType)> {
+        let mut refs = Vec::new();
+        for step in &self.steps {
+            if let Some(skill) = &step.skill {
+                refs.push((skill, RegistryType::Skill));
+            }
+            if let Some(agent) = &step.agent {
+                refs.push((agent, RegistryType::Agent));
+            }
+            if let Some(mcp) = &step.mcp {
+                refs.push((mcp, RegistryType::Mcp));
+            }
+        }
+        refs
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::contracts::ToolType;
+
+    fn make_step(name: &str, action: &str) -> WorkflowStep {
+        let mut step = WorkflowStep {
+            name: name.to_string(),
+            ..Default::default()
+        };
+        match action {
+            "skill" => {
+                step.skill = Some(CardRef {
+                    space: "platform".into(),
+                    name: "my-skill".into(),
+                    version: None,
+                })
+            }
+            "agent" => {
+                step.agent = Some(CardRef {
+                    space: "platform".into(),
+                    name: "my-agent".into(),
+                    version: Some("1.*".into()),
+                })
+            }
+            "prompt" => step.prompt = Some("You are a reviewer.".into()),
+            _ => {}
+        }
+        step
+    }
+
+    #[test]
+    fn test_workflow_spec_roundtrip() {
+        let spec = WorkflowSpec {
+            inputs: {
+                let mut m = HashMap::new();
+                m.insert(
+                    "repo_url".into(),
+                    WorkflowInput {
+                        input_type: "string".into(),
+                        required: true,
+                        default: None,
+                        description: Some("Repository URL".into()),
+                    },
+                );
+                m
+            },
+            steps: vec![
+                make_step("fetch", "skill"),
+                {
+                    let mut s = make_step("review", "agent");
+                    s.depends_on = vec!["fetch".into()];
+                    s
+                },
+            ],
+            outputs: {
+                let mut m = HashMap::new();
+                m.insert("summary".into(), "{{ review.summary }}".into());
+                m
+            },
+        };
+
+        let json = serde_json::to_string(&spec).unwrap();
+        let roundtrip: WorkflowSpec = serde_json::from_str(&json).unwrap();
+        assert_eq!(spec.steps.len(), roundtrip.steps.len());
+        assert_eq!(spec.inputs.len(), roundtrip.inputs.len());
+        assert_eq!(spec.outputs, roundtrip.outputs);
+    }
+
+    #[test]
+    fn test_workflow_spec_defaults_empty() {
+        let spec = WorkflowSpec::default();
+        let json = serde_json::to_string(&spec).unwrap();
+        assert!(!json.contains("inputs"));
+        assert!(!json.contains("outputs"));
+        let roundtrip: WorkflowSpec = serde_json::from_str(&json).unwrap();
+        assert_eq!(spec.steps.len(), roundtrip.steps.len());
+    }
+
+    #[test]
+    fn test_workflow_valid_dag() {
+        let spec = WorkflowSpec {
+            steps: vec![
+                make_step("a", "skill"),
+                {
+                    let mut s = make_step("b", "agent");
+                    s.depends_on = vec!["a".into()];
+                    s
+                },
+                {
+                    let mut s = make_step("c", "prompt");
+                    s.depends_on = vec!["b".into()];
+                    s
+                },
+            ],
+            ..Default::default()
+        };
+        assert!(spec.validate().is_ok());
+    }
+
+    #[test]
+    fn test_workflow_cycle_detection() {
+        let spec = WorkflowSpec {
+            steps: vec![
+                {
+                    let mut s = make_step("a", "skill");
+                    s.depends_on = vec!["b".into()];
+                    s
+                },
+                {
+                    let mut s = make_step("b", "agent");
+                    s.depends_on = vec!["a".into()];
+                    s
+                },
+            ],
+            ..Default::default()
+        };
+        let err = spec.validate().unwrap_err();
+        assert!(err.to_string().contains("cycle"));
+    }
+
+    #[test]
+    fn test_workflow_duplicate_step_names() {
+        let spec = WorkflowSpec {
+            steps: vec![make_step("foo", "skill"), make_step("foo", "agent")],
+            ..Default::default()
+        };
+        let err = spec.validate().unwrap_err();
+        assert!(err.to_string().contains("duplicate step name"));
+    }
+
+    #[test]
+    fn test_workflow_step_requires_action() {
+        let spec = WorkflowSpec {
+            steps: vec![WorkflowStep {
+                name: "empty".into(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let err = spec.validate().unwrap_err();
+        assert!(err.to_string().contains("no action"));
+    }
+
+    #[test]
+    fn test_workflow_missing_depends_on_target() {
+        let spec = WorkflowSpec {
+            steps: vec![{
+                let mut s = make_step("a", "skill");
+                s.depends_on = vec!["nonexistent".into()];
+                s
+            }],
+            ..Default::default()
+        };
+        let err = spec.validate().unwrap_err();
+        assert!(err.to_string().contains("unknown step"));
+    }
+
+    #[test]
+    fn test_workflow_card_refs() {
+        let spec = WorkflowSpec {
+            steps: vec![
+                make_step("s1", "skill"),
+                make_step("s2", "agent"),
+                make_step("s3", "prompt"),
+            ],
+            ..Default::default()
+        };
+        let refs = spec.card_refs();
+        assert_eq!(refs.len(), 2);
+        assert_eq!(refs[0].1, RegistryType::Skill);
+        assert_eq!(refs[1].1, RegistryType::Agent);
+    }
+
+    #[test]
+    fn test_position_json() {
+        let pos = Position { x: 1.0, y: 2.0 };
+        let json = serde_json::to_string(&pos).unwrap();
+        assert_eq!(json, r#"{"x":1.0,"y":2.0}"#);
+        let roundtrip: Position = serde_json::from_str(&json).unwrap();
+        assert_eq!(pos, roundtrip);
+    }
+
+    #[test]
+    fn test_step_display_roundtrip() {
+        let display = StepDisplay {
+            label: Some("Review Code".into()),
+            description: Some("Runs the reviewer agent".into()),
+            icon: Some("robot".into()),
+            position: Some(Position { x: 100.0, y: 200.0 }),
+        };
+        let json = serde_json::to_string(&display).unwrap();
+        let roundtrip: StepDisplay = serde_json::from_str(&json).unwrap();
+        assert_eq!(display, roundtrip);
+    }
+
+    #[test]
+    fn test_workflow_input_type_serializes_as_type() {
+        let input = WorkflowInput {
+            input_type: "string".into(),
+            required: true,
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&input).unwrap();
+        assert!(json.contains(r#""type":"string""#));
+        assert!(!json.contains("inputType"));
+        let roundtrip: WorkflowInput = serde_json::from_str(&json).unwrap();
+        assert_eq!(input, roundtrip);
+    }
+
+    #[test]
+    fn test_card_ref_roundtrip() {
+        let card_ref = CardRef {
+            space: "platform".into(),
+            name: "code-analyzer".into(),
+            version: Some("2.*".into()),
+        };
+        let json = serde_json::to_string(&card_ref).unwrap();
+        let roundtrip: CardRef = serde_json::from_str(&json).unwrap();
+        assert_eq!(card_ref, roundtrip);
+    }
+
+    #[test]
+    fn test_workflow_step_with_tool_roundtrip() {
+        let step = WorkflowStep {
+            name: "fetch".into(),
+            tool: Some(ToolSpec {
+                name: "git-clone".into(),
+                description: "Clone repository".into(),
+                tool_type: ToolType::ShellScript,
+                args_schema: None,
+                output_schema: None,
+                script_config: None,
+                api_config: None,
+                mcp_server_name: None,
+                allowed_tools: vec![],
+                requires_approval: false,
+                hook_events: vec![],
+                hook_matcher: None,
+            }),
+            outputs: vec!["repo_path".into()],
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&step).unwrap();
+        assert!(json.contains("git-clone"));
+        let roundtrip: WorkflowStep = serde_json::from_str(&json).unwrap();
+        assert_eq!(step.name, roundtrip.name);
+        assert!(roundtrip.tool.is_some());
+    }
+}

--- a/crates/opsml_types/src/contracts/workflow.rs
+++ b/crates/opsml_types/src/contracts/workflow.rs
@@ -112,9 +112,32 @@ impl WorkflowSpec {
     /// - every step has at least one action (skill/agent/mcp/tool/prompt)
     /// - the DAG is acyclic (Kahn's algorithm)
     pub fn validate(&self) -> Result<(), TypeError> {
+        const MAX_STEPS: usize = 500;
+        const MAX_DEPS_PER_STEP: usize = 100;
+
+        if self.steps.len() > MAX_STEPS {
+            return Err(TypeError::WorkflowValidation(format!(
+                "workflow exceeds maximum step count ({MAX_STEPS})"
+            )));
+        }
+
         let mut seen_names: HashSet<&str> = HashSet::new();
 
         for step in &self.steps {
+            if step.depends_on.len() > MAX_DEPS_PER_STEP {
+                return Err(TypeError::WorkflowValidation(format!(
+                    "step '{}' exceeds maximum depends_on count ({MAX_DEPS_PER_STEP})",
+                    step.name
+                )));
+            }
+            for key in step.inputs.keys() {
+                if !key.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+                    return Err(TypeError::WorkflowValidation(format!(
+                        "step '{}' input key '{key}' must contain only [a-zA-Z0-9_]",
+                        step.name
+                    )));
+                }
+            }
             if step.name.is_empty() {
                 return Err(TypeError::WorkflowValidation(
                     "step name must not be empty".into(),
@@ -148,22 +171,12 @@ impl WorkflowSpec {
         }
 
         // Kahn's algorithm for cycle detection
+        // in_degree[step] = number of steps that step depends on
         let mut in_degree: HashMap<&str, usize> = self
             .steps
             .iter()
-            .map(|s| (s.name.as_str(), 0))
+            .map(|s| (s.name.as_str(), s.depends_on.len()))
             .collect();
-
-        for step in &self.steps {
-            for dep in &step.depends_on {
-                *in_degree.entry(step.name.as_str()).or_insert(0) += 1;
-                let _ = dep; // dep drives step's in-degree; we already counted above
-            }
-        }
-
-        // Re-compute cleanly: in_degree[step] = number of steps that step depends on
-        let mut in_degree: HashMap<&str, usize> =
-            self.steps.iter().map(|s| (s.name.as_str(), s.depends_on.len())).collect();
 
         // Build reverse adjacency: for each dep, which steps depend on it
         let mut dependents: HashMap<&str, Vec<&str>> = self
@@ -174,7 +187,10 @@ impl WorkflowSpec {
 
         for step in &self.steps {
             for dep in &step.depends_on {
-                dependents.entry(dep.as_str()).or_default().push(step.name.as_str());
+                dependents
+                    .entry(dep.as_str())
+                    .or_default()
+                    .push(step.name.as_str());
             }
         }
 
@@ -271,14 +287,11 @@ mod tests {
                 );
                 m
             },
-            steps: vec![
-                make_step("fetch", "skill"),
-                {
-                    let mut s = make_step("review", "agent");
-                    s.depends_on = vec!["fetch".into()];
-                    s
-                },
-            ],
+            steps: vec![make_step("fetch", "skill"), {
+                let mut s = make_step("review", "agent");
+                s.depends_on = vec!["fetch".into()];
+                s
+            }],
             outputs: {
                 let mut m = HashMap::new();
                 m.insert("summary".into(), "{{ review.summary }}".into());
@@ -472,5 +485,85 @@ mod tests {
         let roundtrip: WorkflowStep = serde_json::from_str(&json).unwrap();
         assert_eq!(step.name, roundtrip.name);
         assert!(roundtrip.tool.is_some());
+    }
+
+    #[test]
+    fn test_workflow_card_refs_includes_mcp() {
+        let mut step = make_step("s1", "skill");
+        step.mcp = Some(CardRef {
+            space: "platform".into(),
+            name: "my-mcp".into(),
+            version: None,
+        });
+        let spec = WorkflowSpec {
+            steps: vec![step],
+            ..Default::default()
+        };
+        let refs = spec.card_refs();
+        assert_eq!(refs.len(), 2);
+        let types: Vec<_> = refs.iter().map(|(_, t)| t).collect();
+        assert!(types.contains(&&RegistryType::Skill));
+        assert!(types.contains(&&RegistryType::Mcp));
+    }
+
+    #[test]
+    fn test_workflow_card_refs_excludes_tool_only_steps() {
+        let skill_step = make_step("s1", "skill");
+        let mut tool_step = WorkflowStep {
+            name: "t1".into(),
+            ..Default::default()
+        };
+        tool_step.tool = Some(ToolSpec {
+            name: "inline-tool".into(),
+            description: "inline".into(),
+            tool_type: ToolType::ShellScript,
+            ..Default::default()
+        });
+        let spec = WorkflowSpec {
+            steps: vec![skill_step, tool_step],
+            ..Default::default()
+        };
+        let refs = spec.card_refs();
+        assert_eq!(refs.len(), 1, "tool-only step must not produce a CardRef");
+        assert_eq!(refs[0].1, RegistryType::Skill);
+    }
+
+    #[test]
+    fn test_workflow_validate_max_steps_exceeded() {
+        let steps: Vec<WorkflowStep> = (0..501)
+            .map(|i| {
+                let mut s = make_step(&format!("s{i}"), "skill");
+                s.name = format!("s{i}");
+                s
+            })
+            .collect();
+        let spec = WorkflowSpec {
+            steps,
+            ..Default::default()
+        };
+        assert!(spec.validate().is_err());
+    }
+
+    #[test]
+    fn test_workflow_validate_inputs_key_must_be_alphanumeric_underscore() {
+        let mut step = make_step("s1", "skill");
+        step.inputs.insert("bad-key".into(), "value".into());
+        let spec = WorkflowSpec {
+            steps: vec![step],
+            ..Default::default()
+        };
+        let err = spec.validate().unwrap_err();
+        assert!(err.to_string().contains("bad-key") || err.to_string().contains("input key"));
+    }
+
+    #[test]
+    fn test_workflow_validate_valid_inputs_key() {
+        let mut step = make_step("s1", "skill");
+        step.inputs.insert("good_key123".into(), "value".into());
+        let spec = WorkflowSpec {
+            steps: vec![step],
+            ..Default::default()
+        };
+        assert!(spec.validate().is_ok());
     }
 }

--- a/crates/opsml_types/src/error.rs
+++ b/crates/opsml_types/src/error.rs
@@ -62,6 +62,9 @@ pub enum TypeError {
 
     #[error("Invalid card type. Expected either Card or CardPath")]
     InvalidCardType,
+
+    #[error("Workflow validation: {0}")]
+    WorkflowValidation(String),
 }
 
 impl From<PythonizeError> for TypeError {

--- a/crates/opsml_types/src/types.rs
+++ b/crates/opsml_types/src/types.rs
@@ -144,6 +144,7 @@ impl From<&ServiceType> for RegistryType {
             ServiceType::Api => RegistryType::Service,
             ServiceType::Mcp => RegistryType::Mcp,
             ServiceType::Agent => RegistryType::Agent,
+            ServiceType::Workflow => RegistryType::Service,
         }
     }
 }

--- a/py-opsml/python/opsml/_opsml.pyi
+++ b/py-opsml/python/opsml/_opsml.pyi
@@ -19697,6 +19697,7 @@ class ServiceType:
     Api: "ServiceType"
     Mcp: "ServiceType"
     Agent: "ServiceType"
+    Workflow: "ServiceType"
 
 class CardRecord:
     uid: Optional[str]


### PR DESCRIPTION
## Pull Request

Closes #356, #357

### Short Summary

Adds `WorkflowSpec` — a DAG-based contract type for multi-step agentic pipelines — and wires it into `ServiceConfig` as a new `Workflow` service type. Hardens `ToolCard` installation with content-hash verification, script validation, and credential stripping in `ApiCallConfig::redacted()`.

### Context

**WorkflowSpec and Workflow service type**

New `crates/opsml_types/src/contracts/workflow.rs` defines the full workflow contract: `WorkflowSpec`, `WorkflowStep`, `CardRef`, and supporting display metadata (`Position`, `StepDisplay`) for a future no-code composer. Steps reference skills, agents, and MCP servers by `space/name/version` via `CardRef`. `WorkflowSpec::validate()` enforces a topological sort — cycles are rejected at parse time, not at runtime.

`ServiceType` gains a `Workflow` variant. `ServiceConfig::validate()` now requires that any service typed as `Workflow` include a `workflow` block; missing it is a hard error. `ServiceConfig` gets an optional `workflow: Option<WorkflowSpec>` field.

The lock action in `opsml-cli` is extended to resolve `CardRef`s from workflow steps into `LockArtifact`s when the spec is a workflow service. Each step's skill/agent/MCP ref is looked up in its respective registry and appended to the lock file.

**ToolCard security hardening (closes #356)**

Three distinct fixes:

1. *Content hash verification.* `pull_artifacts` gains an `expected_hash: Option<&[u8]>` parameter. The `tool install` command now fetches the stored `content_hash` from the registry record before downloading, then passes it to `pull_artifacts`. For `ShellScript` and `Hook` types, the received body is hashed and compared — a mismatch is a hard rejection. This closes the window where tampered script content from a compromised registry record could be written to disk silently.

2. *Script body validation.* Scripts are now checked for a 1 MB size cap and a shebang from an allowlist (`#!/bin/bash`, `#!/bin/sh`, `#!/usr/bin/env bash`, `#!/usr/bin/env sh`) before write. Anything else is an error.

3. *`hook_matcher` tool value validation.* Tool name strings in hook matchers are now length-capped (128 chars) and restricted to `[a-zA-Z0-9_-:]`. Previously, arbitrary strings would pass through to the Claude Code / Gemini / Codex config files.

**`ApiCallConfig::redacted()` credential stripping (closes #357)**

**Before:**
```rust
Self {
    url: self.url.clone(),
    headers,           // sensitive headers stripped, but query string preserved
    body_template: self.body_template.clone(),
}
```

**After:**
```rust
let url = self.url.split_once('?').map(|(base, _)| base.to_string())
    .unwrap_or_else(|| self.url.clone());
Self {
    url,               // query string stripped entirely
    headers,
    body_template: None,  // body template cleared
}
```

Query strings frequently carry API keys (`?api_key=...`, `?token=...`). The previous implementation stripped credential headers but left query params and the body template intact. Both are now cleared in the redacted view.

The sensitive header blocklist also gains `x-amz-security-token`, `x-goog-api-key`, `x-functions-key`, `apikey`, and `token`.

**Atomic writes and Codex config correctness**

All config file writes (Claude Code `settings.json`, Codex `config.yaml`, Gemini settings) now use `tempfile::NamedTempFile::new_in(parent)` + `persist()` instead of `path.with_extension(".tmp")` + `rename()`. The old approach fails silently on cross-device moves (e.g. `tmpfs` → disk). Using `new_in` keeps the temp file on the same filesystem, making the rename atomic.

Codex hook config parsing now uses a typed `CodexConfig` struct instead of `serde_json::Value`. Round-tripping YAML through `serde_json::Value` corrupted multi-line block scalars (`|` style); the typed struct with `#[serde(flatten)]` for unknown fields preserves them correctly.

**Validation deduplication**

`validate_hook_args(events, matcher)` is extracted from three copies of identical inline logic in `ClaudeCodeInstaller`, `GeminiCliInstaller`, and `CodexInstaller`. No behavior change.

| File | Change |
|---|---|
| `crates/opsml_types/src/contracts/workflow.rs` | New — `WorkflowSpec`, `WorkflowStep`, `CardRef`, DAG validation |
| `crates/opsml_types/src/contracts/service.rs` | `ServiceType::Workflow` variant; `ServiceConfig` gets `workflow` field and validation |
| `crates/opsml_types/src/contracts/tool.rs` | `ApiCallConfig::redacted()` strips query string and body template; expands header blocklist |
| `crates/opsml_cards/src/tool/card.rs` | `pull_artifacts` gains `expected_hash` param; script size + shebang validation; hash mismatch rejection |
| `crates/opsml_cards/src/tool/installer.rs` | Typed `CodexConfig`; `NamedTempFile` atomic writes; `validate_hook_args` extraction; `validate_tool_string` |
| `crates/opsml_cli/src/actions/lock.rs` | `resolve_workflow_refs` — resolves step `CardRef`s into lock artifacts for workflow services |
| `crates/opsml_cli/src/actions/tool.rs` | Fetches `content_hash` from registry before download; passes to `pull_artifacts` |
| `crates/opsml_types/src/types.rs` | `ServiceType::Workflow` → `RegistryType::Service` mapping |
| `crates/opsml_types/src/cards/types.rs` | `ServiceType::Workflow` → `CardTable::Service` mapping |
| `crates/opsml_types/src/error.rs` | `TypeError::WorkflowValidation` variant |
| `crates/opsml_cards/src/tool/mod.rs` | Test helper restores original working directory after `set_current_dir` |
| `crates/opsml_cards/Cargo.toml` | `tempfile` moved from `dev-dependencies` to `dependencies` (used in production code now) |
| `py-opsml/python/opsml/_opsml.pyi` | Stub updated for new export |

### Is this a Breaking Change?

Yes — `pull_artifacts` gains a new required `expected_hash: Option<&[u8]>` parameter. Any code calling `pull_artifacts` directly must be updated to pass `None` (to skip hash verification) or a hash fetched from the registry. All existing internal callsites in this PR have been updated.


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/demml/opsml/pull/375" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
