### PR TITLE
Traceid cross page pagination

### DIFF
--- a/crates/opsml_server/opsml_ui/src/lib/components/card/agent/evaluation/AgentEvalDashboard.svelte
+++ b/crates/opsml_server/opsml_ui/src/lib/components/card/agent/evaluation/AgentEvalDashboard.svelte
@@ -48,6 +48,7 @@
   // Working mutable state (refreshed on time range changes)
   let evalData = $state<AgentPromptEvalData[]>(agentPromptEvals);
   let isRefreshing = $state(false);
+  let recordTraceMap = $state(new Map<string, string>());
   // Snapshot on mount so stale singleton state from prior navigation never triggers an immediate refresh.
   let lastSeenRange = $state(timeRangeState.selectedTimeRange);
   let lastSeenSignal = $state(timeRangeState.refreshSignal);
@@ -93,6 +94,7 @@
       console.error('[AgentEvalDashboard] Refresh failed:', err);
     } finally {
       isRefreshing = false;
+      resetRecordTraceMap();
       timeRangeState.endRefresh();
     }
   }
@@ -118,6 +120,7 @@
       console.error('[AgentEvalDashboard] Record page change failed:', err);
     } finally {
       isRefreshing = false;
+      appendToRecordTraceMap();
       timeRangeState.endRefresh();
     }
   }
@@ -145,6 +148,20 @@
       isRefreshing = false;
       timeRangeState.endRefresh();
     }
+  }
+
+  function appendToRecordTraceMap() {
+    evalData.forEach(e => {
+      if (e.monitoringData.status !== 'success') return;
+      e.monitoringData.selectedData.records?.items?.forEach(r => {
+        if (r.trace_id) recordTraceMap.set(r.uid, r.trace_id);
+      });
+    });
+  }
+
+  function resetRecordTraceMap() {
+    recordTraceMap = new Map<string, string>();
+    appendToRecordTraceMap();
   }
 
   // ── Chart ─────────────────────────────────────────────────────────────────────
@@ -290,14 +307,6 @@
   /** Merged workflow page: items from all evals sorted by created_at desc. */
   const workflowPage = $derived(
     (() => {
-      const recordTraceMap = new Map<string, string>();
-      evalData.forEach(e => {
-        if (e.monitoringData.status !== 'success') return;
-        e.monitoringData.selectedData.records?.items?.forEach(r => {
-          if (r.trace_id) recordTraceMap.set(r.uid, r.trace_id);
-        });
-      });
-
       const items: WorkflowWithAgent[] = [];
       let hasNext = false;
       let hasPrevious = false;
@@ -327,6 +336,7 @@
 
     onMount(() => {
       currentMaxPoints = getMaxDataPoints();
+      appendToRecordTraceMap();
       let timeoutId: ReturnType<typeof setTimeout>;
       const handleResize = () => {
         clearTimeout(timeoutId);

--- a/crates/opsml_server/opsml_ui/src/lib/components/card/agent/evaluation/AgentEvalDashboard.svelte
+++ b/crates/opsml_server/opsml_ui/src/lib/components/card/agent/evaluation/AgentEvalDashboard.svelte
@@ -458,7 +458,7 @@
   <!-- ── Evaluation Records Table ──────────────────────────────────────────── -->
   <div class="grid grid-cols-1 gap-6">
   {#if recordPage.items.length > 0 || recordPage.hasPrevious}
-    <div class="bg-white border-2 border-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] rounded-xl overflow-hidden flex flex-col h-full">
+    <div class="bg-white border-2 border-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] rounded-base overflow-hidden flex flex-col h-full">
       <div class="bg-primary-100 border-b-2 border-black px-5 py-3 flex items-center justify-between flex-shrink-0">
         <div class="flex items-center gap-2">
           <TableProperties class="w-4 h-4 text-primary-700" />
@@ -468,7 +468,7 @@
           {recordPage.items.length}
         </span>
       </div>
-      <div class="p-2 w-full flex-grow bg-slate-50 min-h-0">
+      <div class="p-2 w-full flex-grow bg-surface-50 min-h-0">
         <AgentEvalRecordTable
           records={recordPage.items}
           hasNext={recordPage.hasNext}
@@ -481,7 +481,7 @@
   {/if}
 
   {#if workflowPage.items.length > 0 || workflowPage.hasPrevious}
-    <div class="bg-white border-2 border-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] rounded-xl overflow-hidden flex flex-col h-full">
+    <div class="bg-white border-2 border-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] rounded-base overflow-hidden flex flex-col h-full">
       <div class="bg-primary-100 border-b-2 border-black px-5 py-3 flex items-center justify-between flex-shrink-0">
         <div class="flex items-center gap-2">
           <ArrowRightLeft class="w-4 h-4 text-primary-700"/>
@@ -491,7 +491,7 @@
           {workflowPage.items.length}
         </span>
       </div>
-      <div class="p-2 w-full flex-grow bg-slate-50 min-h-0">
+      <div class="p-2 w-full flex-grow bg-surface-50 min-h-0">
         <AgentEvalWorkflowTable
           workflows={workflowPage.items}
           hasNext={workflowPage.hasNext}

--- a/crates/opsml_server/opsml_ui/src/lib/server/card/layout.ts
+++ b/crates/opsml_server/opsml_ui/src/lib/server/card/layout.ts
@@ -38,13 +38,6 @@ export async function loadCardLayout(
   fetch: typeof globalThis.fetch,
   useMockFallback = false,
 ): Promise<CardLayoutData> {
-  if (useMockFallback) {
-    return {
-      ...buildMockCardLayout(registryType, space, name, version),
-      mockMode: true,
-    };
-  }
-
   try {
     const metadata = (await getCardMetadata(
       space,
@@ -69,7 +62,11 @@ export async function loadCardLayout(
       mockMode: false,
     };
   } catch (error) {
-    throw error;
+    if (!useMockFallback) throw error;
+    return {
+      ...buildMockCardLayout(registryType, space, name, version),
+      mockMode: true,
+    };
   }
 }
 
@@ -85,10 +82,6 @@ export async function loadCard(
   fetch: typeof globalThis.fetch,
   useMockFallback = false,
 ): Promise<CardMetadata> {
-  if (useMockFallback) {
-    return buildMockCardMetadata(registryType, space, name, version);
-  }
-
   try {
     const metadata = await getCardMetadata(
       space,
@@ -101,6 +94,7 @@ export async function loadCard(
 
     return metadata as CardMetadata;
   } catch (error) {
-    throw error;
+    if (!useMockFallback) throw error;
+    return buildMockCardMetadata(registryType, space, name, version);
   }
 }

--- a/crates/opsml_server/opsml_ui/src/routes/api/scouter/trace/facets/+server.ts
+++ b/crates/opsml_server/opsml_ui/src/routes/api/scouter/trace/facets/+server.ts
@@ -30,6 +30,13 @@ export const POST: RequestHandler = async ({ request, fetch, cookies }) => {
 
   try {
     const resp = await createOpsmlClient(fetch).post(RoutePaths.TRACE_FACETS, filters);
+    if (!resp.ok) {
+      const errorBody = await resp.text();
+      return json(
+        { response: null, error: errorBody || `Facets request failed: ${resp.status}` },
+        { status: resp.status },
+      );
+    }
     const response = (await resp.json()) as TraceFacetsResponse;
     return json({ response, error: null });
   } catch (error) {

--- a/crates/opsml_server/opsml_ui/src/routes/opsml/agent/[registry]/card/[space]/[name]/[version]/versions/+page.server.ts
+++ b/crates/opsml_server/opsml_ui/src/routes/opsml/agent/[registry]/card/[space]/[name]/[version]/versions/+page.server.ts
@@ -10,14 +10,6 @@ export const load: PageServerLoad = async ({ parent, fetch, cookies }) => {
   const { metadata, registryType } = await parent();
   const useMockFallback = isDevMockEnabled(cookies);
 
-  if (useMockFallback) {
-    return {
-      versionPage: buildMockVersionPage(metadata.space, metadata.name),
-      versionStats: buildMockVersionStats(),
-      mockMode: true,
-    };
-  }
-
   try {
     const [versionPage, versionStats] = await Promise.all([
       getVersionPage(fetch, registryType, metadata.space, metadata.name),
@@ -26,9 +18,7 @@ export const load: PageServerLoad = async ({ parent, fetch, cookies }) => {
 
     return { versionPage, versionStats, mockMode: false };
   } catch (error) {
-    if (!useMockFallback) {
-      throw error;
-    }
+    if (!useMockFallback) throw error;
 
     return {
       versionPage: buildMockVersionPage(metadata.space, metadata.name),


### PR DESCRIPTION
## Pull Request

### Short Summary

Adds deep-link trace navigation from evaluation records and workflows to the Observability dashboard, including a new Rust endpoint (`GET /scouter/trace/{id}/spans`) that fetches a trace without time bounds so the UI can center its time window on the trace automatically. Alongside this, fixes a silent data loss bug where workflow trace links disappeared after paginating records, extracts a shared `DashboardTimeBar` component, and wires global refresh state coordination across evaluation dashboards.

### Context

**Trace deep-link navigation** — Previously, clicking a record or workflow in the evaluation dashboard had no way to jump to the associated trace in Observability. The blocker was that trace lookups require a time range, but the dashboard didn't know what range contained that specific trace. This PR adds `GET /opsml/api/scouter/trace/{id}/spans` to the Rust server — no time bounds, just fetch by ID — then the `+page.ts` load function uses the root span's timestamp to derive a centered time window and pre-selects the trace to open the sidebar immediately on navigation. The trace link appears in `EvalRecordContent`, `AgentEvalWorkflowContent`, and `TaskDetailView`, all building the observability path by stripping `/evaluation` from the current URL.

**`_traceId` cross-page pagination fix** — `workflowPage` was a `$derived` block that rebuilt `recordTraceMap` from the current record page only. Since records and workflows paginate independently, after the user paged records forward, any workflow referencing a record on the previous page silently lost its trace link. Fix: lifted `recordTraceMap` to module-level `$state`, appended to it on each `handleRecordPageChange`, and reset it on full time-range refresh. Svelte 5 proxies Map mutations so the `$derived` recomputes correctly.

**`DashboardTimeBar` extraction** — The refresh button + time range selector combo was duplicated in `TraceDashboard.svelte`. Extracted into `DashboardTimeBar.svelte` with `selectedRange`, `refreshing`, `onRangeChange`, and `onRefresh` props. `TraceDashboard` now uses it directly.

**Global refresh state** — Added `isRefreshing`, `beginRefresh()`, and `endRefresh()` to `timeRangeState`. Evaluation dashboards (`AgentEvalDashboard`, `PromptEvalDashboard`) now call these around every fetch so the global time bar can show a loading state without each dashboard managing it independently. Also prevents `timeRangeState.refresh()` from double-firing if already in progress.

**`PromptEvalDashboard` range-change detection** — The previous detection compared `monitoringData.selectedTimeRange` to the new range, but that field gets mutated by the same effect, creating an unreliable comparison. Replaced with a stable `lastSeenRange` snapshot (same fix applied to `AgentEvalDashboard` in an earlier commit). Also removed the floating "Syncing..." overlay — the global refresh state handles this now.

**`ComparisonView.svelte` string rendering** — Plain string expected/actual values were being routed through a JSON `CodeBlock`, which escaped and syntax-highlighted them as JSON. Strings now render as `<span class="font-mono whitespace-pre-wrap">` and only objects go through `CodeBlock`.

**`isPromptCard` comparison fix** — The type guard was using `===` against `RegistryType.Prompt` (a lowercase string enum), but `card.registry_type` coming from the API could have different casing depending on serialization. Changed to `String(card.registry_type).toLowerCase() === RegistryType.Prompt`.

**Mock mode for task loading** — `AgentEvalWorkflowContent` was gating mock task data with `import { dev } from '$app/environment'`, which means it only worked in dev builds, not when the mock toggle was on in production-like environments. Changed to `devMockStore.enabled`.

| File | Change |
|---|---|
| `src/core/scouter/trace/route.rs` | New `GET /scouter/trace/{id}/spans` endpoint, registered in router |
| `src/lib/components/utils/DashboardTimeBar.svelte` | New shared time bar component (refresh button + range selector) |
| `src/lib/components/utils/timeState.svelte.ts` | Added `isRefreshing`, `beginRefresh()`, `endRefresh()` |
| `src/lib/components/card/agent/evaluation/AgentEvalDashboard.svelte` | Persistent `recordTraceMap`, `beginRefresh`/`endRefresh` wiring, style fixes |
| `src/lib/components/card/prompt/PromptEvalDashboard.svelte` | Stable `lastSeenRange`, removed floating overlay, refresh wiring |
| `src/lib/components/trace/TraceDashboard.svelte` | Uses `DashboardTimeBar`, passes `initialTrace`/`initialTraceSpans`, strips `trace_id` param on refresh |
| `src/lib/components/trace/utils.ts` | `getServerTraceSpansById`, `traceListItemFromSpans` helpers |
| `routes/api/scouter/observability/trace/[id]/spans/+server.ts` | New BFF proxy for spans-by-ID |
| `routes/.../observability/+page.ts` | Pre-fetches trace by `?trace_id=` param, derives centered time window |
| `src/lib/components/scouter/agent/record/EvalRecordContent.svelte` | "Trace" link button navigating to observability |
| `src/lib/components/scouter/agent/workflow/AgentEvalWorkflowContent.svelte` | Passes `traceId` + observability path through to `TaskDetailView`, switches to `devMockStore` |
| `src/lib/components/scouter/agent/task/TaskDetailView.svelte` | "Trace" link button at task level |
| `src/lib/components/scouter/agent/task/ComparisonView.svelte` | String values rendered as plain text, not JSON CodeBlock |
| `src/lib/components/card/card_interfaces/promptcard.ts` | Case-insensitive `isPromptCard` registry type comparison |
| `src/lib/components/scouter/dashboard/utils.test.ts` | Tests for `refreshAgentMonitoringData` mock and time-range behavior |
| `src/lib/components/utils/DashboardTimeBar.test.ts` | Tests for new component |
| `src/lib/components/utils/timeState.test.ts` | Tests for refresh state |

### Is this a Breaking Change?

No. The new Rust endpoint is additive. All existing TypeScript types are extended with optional fields (`_traceId?: string`, `trace_id?: string`, `initialTrace?`, `initialTraceSpans?`) and no existing prop signatures changed. The `DashboardTimeBar` extraction doesn't affect any other callers since `TimeRangeFilter` is still exported. The `isPromptCard` fix changes behavior only for cards where the API returns non-lowercase `registry_type`, which was already broken.


